### PR TITLE
fix: seed home volume from image and add SELinux :z label

### DIFF
--- a/ai-pod.Dockerfile
+++ b/ai-pod.Dockerfile
@@ -5,14 +5,15 @@ WORKDIR /app
 RUN useradd -ms /bin/bash claude
 RUN chown -R claude /app
 
-# Install claude as root then move to system-wide location
-RUN curl -fsSL https://claude.ai/install.sh | bash && \
-    mv /root/.local/bin/claude /usr/local/bin/claude
-
 # System-level git identity
 RUN git config --system user.email "claude@ai-pod" && \
     git config --system user.name "claude"
 
 USER claude
+
+ENV PATH="/home/claude/.local/bin:${PATH}"
+
+# Install claude as the claude user so all symlinks/node modules land in ~/.local/
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 CMD ["claude"]

--- a/claude.Dockerfile
+++ b/claude.Dockerfile
@@ -7,14 +7,15 @@ WORKDIR /app
 RUN useradd -ms /bin/bash claude
 RUN chown -R claude /app
 
-# Install claude as root then move to system-wide location
-RUN curl -fsSL https://claude.ai/install.sh | bash && \
-    mv /root/.local/bin/claude /usr/local/bin/claude
-
 # System-level git identity
 RUN git config --system user.email "claude@ai-pod" && \
     git config --system user.name "claude"
 
 USER claude
+
+ENV PATH="/home/claude/.local/bin:${PATH}"
+
+# Install claude as the claude user so all symlinks/node modules land in ~/.local/
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 CMD ["claude"]


### PR DESCRIPTION
Install claude as the claude user so binaries land in ~/.local/bin
instead of being moved from root. Seed the home volume by copying from
the image's /home/claude (preserving the claude install) rather than
creating an empty skeleton. Add :z to the volume mount so SELinux
allows access in fresh containers.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
