### PR TITLE
Add fork command to create worktree-based parallel pods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,8 @@ dependencies = [
  "hex",
  "libc",
  "notify-rust",
+ "petname",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -537,6 +539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1048,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1305,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petname"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
+dependencies = [
+ "anyhow",
+ "clap",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,7 +1445,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1463,12 +1494,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1478,7 +1530,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,11 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
 notify-rust = "4"
+petname = "2"
 tempfile = "3"
 tokio-stream = "0.1"
 futures-util = "0.3"
+rand = "0.8"
 
 [[bin]]
 name = "host-tools"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,12 @@ pub enum Command {
         args: Vec<String>,
     },
 
+    /// Fork the current workspace into a git worktree with its own container
+    Fork {
+        /// Name for the fork (generates a mnemonic if omitted)
+        name: Option<String>,
+    },
+
     /// Manage the whitelist of always-allowed commands for a workspace
     Allowed {
         #[command(subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,11 @@ impl AppConfig {
         self.home_dir.join(".claude").join("CLAUDE.md")
     }
 
+    /// Returns path to the worktrees directory: ~/.ai-pod/worktrees/
+    pub fn worktrees_dir(&self) -> PathBuf {
+        self.config_dir.join("worktrees")
+    }
+
     /// Returns the directory for storing moved credential files for a given workspace.
     /// E.g., `/home/user/my-project` → `~/.env-files/home-user-my-project/`
     pub fn env_files_project_dir(&self, workspace: &Path) -> PathBuf {

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored::Colorize;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
@@ -240,6 +240,55 @@ pub fn check_credentials(workspace: &Path, config: &AppConfig) -> Result<bool> {
     }
 
     Ok(true)
+}
+
+pub fn link_credentials_to_worktree(original_workspace: &Path, worktree: &Path) -> Result<()> {
+    let original_workspace =
+        std::fs::canonicalize(original_workspace).unwrap_or_else(|_| original_workspace.to_path_buf());
+    let found = scan_workspace(&original_workspace);
+    if found.is_empty() {
+        return Ok(());
+    }
+
+    let mut linked = 0;
+    for original_path in &found {
+        let rel = match original_path.strip_prefix(&original_workspace) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let dest = worktree.join(rel);
+
+        if dest.exists() || dest.symlink_metadata().is_ok() {
+            continue;
+        }
+
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        if original_path.symlink_metadata().is_ok_and(|m| m.file_type().is_symlink()) {
+            let target = std::fs::read_link(original_path)
+                .with_context(|| format!("Failed to read symlink {}", original_path.display()))?;
+            std::os::unix::fs::symlink(&target, &dest)
+                .with_context(|| format!("Failed to symlink {}", dest.display()))?;
+        } else {
+            std::os::unix::fs::symlink(original_path, &dest)
+                .with_context(|| format!("Failed to symlink {}", dest.display()))?;
+        }
+        linked += 1;
+    }
+
+    if linked > 0 {
+        use colored::Colorize;
+        println!(
+            "{} Linked {} credential file{} into worktree",
+            "✓".green(),
+            linked,
+            if linked == 1 { "" } else { "s" }
+        );
+    }
+
+    Ok(())
 }
 
 fn move_and_symlink(src: &Path, dst: &Path) -> Result<()> {

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -1,0 +1,166 @@
+use anyhow::{bail, Context, Result};
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::config::AppConfig;
+
+fn generate_name() -> Option<String> {
+    use petname::Generator;
+    let mut rng = rand::thread_rng();
+    petname::Petnames::default().generate(&mut rng, 2, "-")
+}
+
+fn validate_fork_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("Fork name must not be empty.");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        bail!("Fork name must contain only lowercase letters, numbers, and hyphens.");
+    }
+    if name.starts_with('-') {
+        bail!("Fork name must not start with a hyphen.");
+    }
+    Ok(())
+}
+
+fn is_git_repo(workspace: &Path) -> bool {
+    Command::new("git")
+        .args(["-C", &workspace.to_string_lossy(), "rev-parse", "--git-dir"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+fn branch_exists(workspace: &Path, branch: &str) -> bool {
+    Command::new("git")
+        .args([
+            "-C",
+            &workspace.to_string_lossy(),
+            "rev-parse",
+            "--verify",
+            branch,
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+pub fn create_fork(
+    config: &AppConfig,
+    workspace: &Path,
+    name: Option<&str>,
+) -> Result<(String, PathBuf)> {
+    if !is_git_repo(workspace) {
+        bail!("Current directory is not a git repository. Fork requires git.");
+    }
+
+    let fork_name = match name {
+        Some(n) => {
+            validate_fork_name(n)?;
+            n.to_string()
+        }
+        None => {
+            let mut attempts = 0;
+            loop {
+                let candidate =
+                    generate_name().context("Failed to generate a fork name")?;
+                let worktree_path = config.worktrees_dir().join(&candidate);
+                if !worktree_path.exists() {
+                    break candidate;
+                }
+                attempts += 1;
+                if attempts >= 10 {
+                    bail!(
+                        "Failed to generate a unique fork name after 10 attempts. \
+                         Please specify a name explicitly."
+                    );
+                }
+            }
+        }
+    };
+
+    let worktree_path = config.worktrees_dir().join(&fork_name);
+    let branch_name = format!("fork/{}", fork_name);
+
+    if worktree_path.exists() {
+        bail!(
+            "Fork name '{}' already exists at {}. Choose a different name or remove the existing worktree.",
+            fork_name,
+            worktree_path.display()
+        );
+    }
+
+    if branch_exists(workspace, &branch_name) {
+        bail!(
+            "Branch '{}' already exists. Choose a different fork name.",
+            branch_name
+        );
+    }
+
+    std::fs::create_dir_all(config.worktrees_dir())
+        .context("Failed to create worktrees directory")?;
+
+    let output = Command::new("git")
+        .args([
+            "-C",
+            &workspace.to_string_lossy(),
+            "worktree",
+            "add",
+            "-b",
+            &branch_name,
+            &worktree_path.to_string_lossy(),
+        ])
+        .output()
+        .context("Failed to run git worktree add")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to create git worktree: {}", stderr.trim());
+    }
+
+    println!(
+        "{} {} (branch {})",
+        "Fork created:".green().bold(),
+        fork_name,
+        branch_name.blue()
+    );
+    println!("{} {}", "Worktree:".blue(), worktree_path.display());
+
+    Ok((fork_name, worktree_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_fork_names() {
+        assert!(validate_fork_name("my-fork").is_ok());
+        assert!(validate_fork_name("test123").is_ok());
+        assert!(validate_fork_name("a").is_ok());
+        assert!(validate_fork_name("abc-def-ghi").is_ok());
+    }
+
+    #[test]
+    fn invalid_fork_names() {
+        assert!(validate_fork_name("").is_err());
+        assert!(validate_fork_name("-leading").is_err());
+        assert!(validate_fork_name("UPPER").is_err());
+        assert!(validate_fork_name("has space").is_err());
+        assert!(validate_fork_name("has_underscore").is_err());
+    }
+
+    #[test]
+    fn generate_name_returns_two_words() {
+        let name = generate_name().unwrap();
+        assert!(name.contains('-'), "expected hyphen in '{}'", name);
+        let parts: Vec<&str> = name.split('-').collect();
+        assert_eq!(parts.len(), 2, "expected 2 parts in '{}'", name);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod config;
 mod container;
 mod credentials;
+mod fork;
 mod image;
 mod server;
 mod update;
@@ -43,15 +44,17 @@ fn init_project(workspace: &Path) -> Result<()> {
     Ok(())
 }
 
-async fn launch_flow(cli: &Cli) -> Result<()> {
+async fn launch_flow(
+    workspace: &Path,
+    no_credential_check: bool,
+    rebuild: bool,
+) -> Result<()> {
     let config = AppConfig::new()?;
     config.init()?;
 
-    // 1. Resolve workspace
-    let workspace = resolve_workspace(&cli.workdir)?;
     println!("{} {}", "Workspace:".blue(), workspace.display());
 
-    // 2. Locate Dockerfile
+    // 1. Locate Dockerfile
     let dockerfile = workspace.join(image::DOCKERFILE_NAME);
     if !dockerfile.exists() {
         anyhow::bail!(
@@ -61,36 +64,36 @@ async fn launch_flow(cli: &Cli) -> Result<()> {
         );
     }
 
-    // 3. Credential scan
-    if !cli.no_credential_check {
-        if !credentials::check_credentials(&workspace, &config)? {
+    // 2. Credential scan
+    if !no_credential_check {
+        if !credentials::check_credentials(workspace, &config)? {
             println!("{}", "Aborted.".red());
             return Ok(());
         }
     }
 
-    // 4. Build image if needed
-    let image = image::image_name(&workspace);
-    image::ensure_image(&config, &dockerfile, &image, cli.rebuild)?;
+    // 3. Build image if needed
+    let image = image::image_name(workspace);
+    image::ensure_image(&config, &dockerfile, &image, rebuild)?;
 
-    // 5. Ensure shared server is running
+    // 4. Ensure shared server is running
     server::lifecycle::ensure_shared_server(&config)?;
 
-    // 6. Check server version compatibility
+    // 5. Check server version compatibility
     server::lifecycle::check_server_version().await?;
 
-    // 7. Get or create project state (stable api_key)
-    let project_id = workspace::workspace_hash(&workspace);
-    let state = server::lifecycle::get_or_create_project_state(&config, &workspace)?;
+    // 6. Get or create project state (stable api_key)
+    let project_id = workspace::workspace_hash(workspace);
+    let state = server::lifecycle::get_or_create_project_state(&config, workspace)?;
 
-    // 8. Reload server config so it picks up the updated project file
+    // 7. Reload server config so it picks up the updated project file
     server::lifecycle::reload_config().await?;
 
-    // 9. Launch container
+    // 8. Launch container
     container::launch_container(
         &config,
-        &workspace,
-        cli.rebuild,
+        workspace,
+        rebuild,
         &image,
         &project_id,
         &state.api_key,
@@ -219,8 +222,18 @@ async fn main() -> Result<()> {
                 }
             }
         }
+        Some(Command::Fork { name }) => {
+            let config = AppConfig::new()?;
+            config.init()?;
+            let workspace = resolve_workspace(&cli.workdir)?;
+            let (_fork_name, worktree_path) =
+                fork::create_fork(&config, &workspace, name.as_deref())?;
+            credentials::link_credentials_to_worktree(&workspace, &worktree_path)?;
+            launch_flow(&worktree_path, cli.no_credential_check, cli.rebuild).await?;
+        }
         None => {
-            launch_flow(&cli).await?;
+            let workspace = resolve_workspace(&cli.workdir)?;
+            launch_flow(&workspace, cli.no_credential_check, cli.rebuild).await?;
         }
     }
 


### PR DESCRIPTION
The `ai-pod fork [name]` command creates a git worktree in
~/.ai-pod/worktrees/<name>/, links credential files from the
original workspace, and launches an independent pod on the new
worktree. Names are auto-generated using the petname crate when
not provided.

https://claude.ai/code/session_015N9vPffzkhrtRX5B7WMKbt