### PR TITLE
Pin Ubuntu base image to version 24.04

### DIFF
--- a/claude.Dockerfile
+++ b/claude.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y curl git vim
 


### PR DESCRIPTION
## Summary
Updated the Dockerfile to use a specific Ubuntu version instead of the latest tag, improving build reproducibility and stability.

## Key Changes
- Changed base image from `ubuntu:latest` to `ubuntu:24.04`

## Implementation Details
Using a pinned version (24.04) instead of the `latest` tag ensures consistent builds across different environments and times. This prevents unexpected breaking changes that could occur when Ubuntu releases new versions, making the Docker image more reliable and predictable for CI/CD pipelines and deployments.

https://claude.ai/code/session_0148Dc4S2t8eHTPksNvfECzZ