### PR TITLE
Restrict daemon and server log file permissions to 0o600

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "memchr",
  "serde",
  "serde_derive",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]

--- a/src/server/daemons.rs
+++ b/src/server/daemons.rs
@@ -253,6 +253,20 @@ pub async fn cleanup_orphaned_daemons(state: &AppState) {
     }
 }
 
+// ──── File helpers ───────────────────────────────────────────────────────────
+
+/// Open a daemon log file for append with owner-only permissions (0o600).
+/// Daemon logs capture full stdout/stderr of approved host commands and must
+/// not be readable by other local users.
+async fn open_daemon_log(path: &std::path::Path) -> std::io::Result<tokio::fs::File> {
+    tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .open(path)
+        .await
+}
+
 // ──── Handlers ───────────────────────────────────────────────────────────────
 
 pub async fn start_daemon_handler(
@@ -365,12 +379,7 @@ pub async fn start_daemon_handler(
     let daemon_id_clone = daemon_id.clone();
     let state_clone = state.clone();
     tokio::spawn(async move {
-        let log_file = match tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&log_path)
-            .await
-        {
+        let log_file = match open_daemon_log(&log_path).await {
             Ok(f) => f,
             Err(_) => return,
         };
@@ -628,6 +637,20 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
     use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn daemon_log_file_has_restrictive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("daemon.log");
+        let _file = open_daemon_log(&path).await.unwrap();
+        let perms = std::fs::metadata(&path).unwrap().permissions();
+        assert_eq!(
+            perms.mode() & 0o777,
+            0o600,
+            "daemon log must be owner read/write only (0600)"
+        );
+    }
 
     // ── Shared helpers ────────────────────────────────────────────────────────
 

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -85,6 +85,18 @@ fn is_process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 
+/// Create the shared server log file with owner-only permissions (0o600).
+/// Truncates any existing file, matching `File::create` semantics, so each
+/// shared-server start gets a fresh log.
+fn create_server_log(path: &Path) -> std::io::Result<std::fs::File> {
+    OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+}
+
 #[allow(dead_code)]
 pub fn state_file_for(config: &AppConfig, workspace: &Path) -> PathBuf {
     let hash = workspace_hash(workspace);
@@ -107,7 +119,7 @@ pub fn ensure_shared_server(config: &AppConfig) -> Result<()> {
 
     let exe = std::env::current_exe().context("Failed to get current executable path")?;
     let log_path = config.config_dir.join("server.log");
-    let log = std::fs::File::create(&log_path).context("Failed to create server log file")?;
+    let log = create_server_log(&log_path).context("Failed to create server log file")?;
     let log_err = log.try_clone()?;
 
     let child = Command::new(&exe)
@@ -264,6 +276,20 @@ mod tests {
             perms.mode() & 0o777,
             0o600,
             "state file must be owner read/write only (0600)"
+        );
+    }
+
+    #[test]
+    fn server_log_file_has_restrictive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("server.log");
+        let _file = create_server_log(&path).unwrap();
+        let perms = std::fs::metadata(&path).unwrap().permissions();
+        assert_eq!(
+            perms.mode() & 0o777,
+            0o600,
+            "server log must be owner read/write only (0600)"
         );
     }
 


### PR DESCRIPTION
## Summary
This PR enhances security by ensuring daemon and server log files are created with restrictive owner-only permissions (0o600), preventing other local users from reading sensitive command output and logs.

## Key Changes
- **daemons.rs**: 
  - Extracted log file creation into a new `open_daemon_log()` helper function that creates files with 0o600 permissions
  - Updated `start_daemon_handler()` to use the new helper instead of inline `OpenOptions`
  - Added test `daemon_log_file_has_restrictive_permissions()` to verify permissions are correctly set

- **lifecycle.rs**:
  - Extracted server log file creation into a new `create_server_log()` helper function that creates files with 0o600 permissions
  - Updated `ensure_shared_server()` to use the new helper instead of `File::create()`
  - Added test `server_log_file_has_restrictive_permissions()` to verify permissions are correctly set

## Implementation Details
- Both helper functions use `tokio::fs::OpenOptions` (async) and `std::fs::OpenOptions` (sync) respectively with the `.mode(0o600)` option
- The `create_server_log()` function uses `.truncate(true)` to match `File::create()` semantics, ensuring each server start gets a fresh log
- Tests verify that created files have exactly 0o600 permissions using `PermissionsExt::mode()`
- This prevents unauthorized local users from accessing daemon command output and server logs

https://claude.ai/code/session_01R61AwyVHgbcm79kc3so1oW