### PR TITLE
Fix PID-reuse race conditions in daemon and command handlers

### DIFF
--- a/src/server/daemons.rs
+++ b/src/server/daemons.rs
@@ -467,13 +467,28 @@ pub async fn start_daemon_handler(
                     // Kill the whole process group (see
                     // `.process_group(0)` on spawn) so children of
                     // `sh` are caught too.
-                    unsafe {
-                        libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
+                    let ret = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGTERM) };
+                    debug_assert_eq!(ret, 0, "kill({}, SIGTERM) failed: {}", pid, std::io::Error::last_os_error());
+                    // Give the process group a grace period, then escalate to SIGKILL
+                    // to handle processes that ignore SIGTERM.
+                    tokio::select! {
+                        res = child.wait() => match res {
+                            Ok(status) => status.code().unwrap_or(-1),
+                            Err(_) => -1,
+                        },
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                            let _ = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+                            match child.wait().await {
+                                Ok(status) => status.code().unwrap_or(-1),
+                                Err(_) => -1,
+                            }
+                        }
                     }
-                }
-                match child.wait().await {
-                    Ok(status) => status.code().unwrap_or(-1),
-                    Err(_) => -1,
+                } else {
+                    match child.wait().await {
+                        Ok(status) => status.code().unwrap_or(-1),
+                        Err(_) => -1,
+                    }
                 }
             }
         };
@@ -1568,39 +1583,22 @@ mod tests {
             //   1. receive the oneshot kill signal,
             //   2. send SIGTERM to the process group,
             //   3. call child.wait() which reaps the child,
-            //   4. consume the DaemonEntry.kill_tx (already taken by the stop handler),
-            //   5. leave status == Killed (preserved by the Running-guard).
-            // The entry's status is already Killed (set synchronously), but
-            // we need to confirm the reaper actually ran and didn't hang.
-            for _ in 0..400 {
-                let reaped = {
-                    let daemons = state.daemons.lock().await;
-                    let entry = &daemons[&daemon_id];
-                    // kill_tx was taken by the stop handler; the reaper then
-                    // consumed the receiver and exited. There is no direct
-                    // "reaper finished" flag, but the child log file will
-                    // have the Exit message written after wait() returns.
-                    entry.kill_tx.is_none() && entry.status == DaemonStatus::Killed
-                };
-                if reaped {
-                    // Extra: briefly confirm the log file now contains an Exit line.
-                    let log_path = {
-                        let daemons = state.daemons.lock().await;
-                        daemons[&daemon_id].log_path.clone()
-                    };
-                    for _ in 0..200 {
-                        if let Ok(bytes) = tokio::fs::read(&log_path).await
-                            && String::from_utf8_lossy(&bytes).contains("\"Exit\"")
-                        {
-                            return;
-                        }
-                        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-                    }
-                    panic!("reaper ran but never wrote Exit to the log file");
+            //   4. write the Exit message to the log file.
+            // Poll the log file for the Exit message as the definitive signal
+            // that the reaper has fully completed (not just that kill_tx was taken).
+            let log_path = {
+                let daemons = state.daemons.lock().await;
+                daemons[&daemon_id].log_path.clone()
+            };
+            for _ in 0..200 {
+                if let Ok(bytes) = tokio::fs::read(&log_path).await
+                    && String::from_utf8_lossy(&bytes).contains("\"Exit\"")
+                {
+                    return;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(25)).await;
             }
-            panic!("daemon '{}' kill_tx was never consumed", daemon_id);
+            panic!("reaper never wrote Exit to the log file for daemon '{}'", daemon_id);
         }
 
         #[tokio::test]

--- a/src/server/daemons.rs
+++ b/src/server/daemons.rs
@@ -31,7 +31,12 @@ pub struct DaemonEntry {
     pub command: String,
     pub started_at: std::time::SystemTime,
     pub status: DaemonStatus,
-    pub pid: Option<u32>,
+    /// Oneshot to ask the reaper task (which owns `Child`) to terminate
+    /// the daemon. Sending is safe from PID reuse because the reaper
+    /// cannot have called `child.wait()` yet — the kernel therefore has
+    /// not recycled the PID. `None` means the sender has already been
+    /// consumed by a prior stop call; sending is a no-op either way.
+    pub kill_tx: Option<tokio::sync::oneshot::Sender<()>>,
     pub log_path: PathBuf,
 }
 
@@ -177,7 +182,7 @@ async fn gc_old_daemon_logs(state: AppState) {
 }
 
 async fn stop_all_daemons_for_project(state: &AppState, project_id: &str) -> usize {
-    let mut pids: Vec<u32> = Vec::new();
+    let mut kill_txs: Vec<tokio::sync::oneshot::Sender<()>> = Vec::new();
     let mut count = 0;
     {
         let mut daemons = state.daemons.lock().await;
@@ -185,18 +190,17 @@ async fn stop_all_daemons_for_project(state: &AppState, project_id: &str) -> usi
             if entry.project_id == project_id && entry.status == DaemonStatus::Running {
                 entry.status = DaemonStatus::Killed;
                 count += 1;
-                if let Some(pid) = entry.pid {
-                    pids.push(pid);
+                if let Some(tx) = entry.kill_tx.take() {
+                    kill_txs.push(tx);
                 }
             }
         }
     }
-    for pid in pids {
-        if pid > 0 {
-            unsafe {
-                libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
-            }
-        }
+    for tx in kill_txs {
+        // Err means the reaper has already finished (child exited naturally).
+        // Status was set to Killed above and the reaper's status-update guard
+        // preserves it, so this is a graceful no-op.
+        let _ = tx.send(());
     }
     count
 }
@@ -354,9 +358,16 @@ pub async fn start_daemon_handler(
         }
     };
 
-    let pid = child.id();
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
+
+    // Oneshot used by stop_daemon_handler / stop_all_daemons_for_project to
+    // ask the reaper task (which owns `child` and therefore pins the PID)
+    // to send SIGTERM. Routing kill requests through the reaper eliminates
+    // the PID-reuse TOCTOU: the kernel cannot recycle the child's PID
+    // until `Child::wait()` returns, and the reaper only calls `wait()`
+    // after either seeing a natural exit or performing the kill itself.
+    let (kill_tx, kill_rx) = tokio::sync::oneshot::channel::<()>();
 
     // Insert entry before spawning reaper
     {
@@ -369,7 +380,7 @@ pub async fn start_daemon_handler(
                 command: req.command.clone(),
                 started_at: std::time::SystemTime::now(),
                 status: DaemonStatus::Running,
-                pid,
+                kill_tx: Some(kill_tx),
                 log_path: log_path.clone(),
             },
         );
@@ -436,10 +447,35 @@ pub async fn start_daemon_handler(
             writer
         });
 
-        // Wait for child to exit
-        let exit_code = match child.wait().await {
-            Ok(status) => status.code().unwrap_or(-1),
-            Err(_) => -1,
+        // Wait for child to exit OR for a kill request from the stop
+        // handlers. Because this task owns `child`, the kernel cannot
+        // recycle the PID until we call `child.wait()` to completion —
+        // so `child.id()` in the kill branch is guaranteed to still
+        // reference this daemon's process group. This closes the
+        // PID-reuse TOCTOU that motivated issue #29.
+        let exit_code = tokio::select! {
+            res = child.wait() => {
+                match res {
+                    Ok(status) => status.code().unwrap_or(-1),
+                    Err(_) => -1,
+                }
+            }
+            _ = kill_rx => {
+                if let Some(pid) = child.id()
+                    && pid > 0
+                {
+                    // Kill the whole process group (see
+                    // `.process_group(0)` on spawn) so children of
+                    // `sh` are caught too.
+                    unsafe {
+                        libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
+                    }
+                }
+                match child.wait().await {
+                    Ok(status) => status.code().unwrap_or(-1),
+                    Err(_) => -1,
+                }
+            }
         };
 
         // Wait for both I/O pumps to finish
@@ -479,7 +515,7 @@ pub async fn stop_daemon_handler(
         return (status, msg.to_string()).into_response();
     }
 
-    let pid = {
+    let kill_tx = {
         let mut daemons = state.daemons.lock().await;
         match daemons.get_mut(&req.daemon_id) {
             None => return (StatusCode::NOT_FOUND, "Unknown daemon").into_response(),
@@ -491,17 +527,16 @@ pub async fn stop_daemon_handler(
             }
             Some(entry) => {
                 entry.status = DaemonStatus::Killed;
-                entry.pid
+                entry.kill_tx.take()
             }
         }
     };
 
-    if let Some(pid) = pid {
-        if pid > 0 {
-            unsafe {
-                libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
-            }
-        }
+    if let Some(tx) = kill_tx {
+        // Err means the reaper has already finished (child exited naturally).
+        // Status was set to Killed above and the reaper's status-update guard
+        // preserves it, so this is a graceful no-op.
+        let _ = tx.send(());
     }
 
     Json(serde_json::json!({"ok": true})).into_response()
@@ -666,7 +701,7 @@ mod tests {
             command: "test-command".to_string(),
             started_at: std::time::SystemTime::now(),
             status,
-            pid: None,
+            kill_tx: None,
             log_path,
         }
     }
@@ -755,7 +790,7 @@ mod tests {
             command: "sleep 10".to_string(),
             started_at: std::time::UNIX_EPOCH + std::time::Duration::from_secs(1000),
             status: DaemonStatus::Running,
-            pid: Some(1234),
+            kill_tx: None,
             log_path: PathBuf::from("/tmp/test.log"),
         };
         let meta = DaemonMeta::from_entry(&entry);
@@ -815,7 +850,7 @@ mod tests {
             command: "cmd".to_string(),
             started_at: std::time::UNIX_EPOCH,
             status: DaemonStatus::Running,
-            pid: None,
+            kill_tx: None,
             log_path: PathBuf::from("/tmp/d1.log"),
         };
         let meta = DaemonMeta::from_entry(&entry);
@@ -868,7 +903,7 @@ mod tests {
                 command: "true".to_string(),
                 started_at: std::time::UNIX_EPOCH, // ancient
                 status: DaemonStatus::Finished { exit_code: 0 },
-                pid: None,
+                kill_tx: None,
                 log_path: log_path.clone(),
             },
         );
@@ -897,7 +932,7 @@ mod tests {
                 command: "sleep 9999".to_string(),
                 started_at: std::time::UNIX_EPOCH,
                 status: DaemonStatus::Killed,
-                pid: None,
+                kill_tx: None,
                 log_path: log_path.clone(),
             },
         );
@@ -945,7 +980,7 @@ mod tests {
                 command: "echo hi".to_string(),
                 started_at: std::time::SystemTime::now(), // just started
                 status: DaemonStatus::Finished { exit_code: 0 },
-                pid: None,
+                kill_tx: None,
                 log_path: log_path.clone(),
             },
         );
@@ -1497,6 +1532,116 @@ mod tests {
             assert_eq!(daemons[&daemon_id].status, DaemonStatus::Killed);
         }
 
+        #[tokio::test]
+        async fn stop_terminates_long_running_child() {
+            // Proves the oneshot-routed kill signal reaches the reaper and
+            // the child actually terminates (no PID-reuse TOCTOU).
+            let dir = TempDir::new().unwrap();
+            let state = make_state(dir.path());
+            pre_allow(dir.path(), dir.path(), "sleep 60");
+            let router = make_router(state.clone());
+
+            let start_resp = router
+                .oneshot(json_req(
+                    "/daemon/start",
+                    "key1",
+                    serde_json::json!({"project_id": "proj1", "command": "sleep 60"}),
+                ))
+                .await
+                .unwrap();
+            let daemon_id = to_json(start_resp).await["daemon_id"]
+                .as_str()
+                .unwrap()
+                .to_string();
+
+            let stop_resp = make_router(state.clone())
+                .oneshot(json_req(
+                    "/daemon/stop",
+                    "key1",
+                    serde_json::json!({"project_id": "proj1", "daemon_id": daemon_id.clone()}),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(stop_resp.status(), axum::http::StatusCode::OK);
+
+            // After a stop request the reaper should:
+            //   1. receive the oneshot kill signal,
+            //   2. send SIGTERM to the process group,
+            //   3. call child.wait() which reaps the child,
+            //   4. consume the DaemonEntry.kill_tx (already taken by the stop handler),
+            //   5. leave status == Killed (preserved by the Running-guard).
+            // The entry's status is already Killed (set synchronously), but
+            // we need to confirm the reaper actually ran and didn't hang.
+            for _ in 0..400 {
+                let reaped = {
+                    let daemons = state.daemons.lock().await;
+                    let entry = &daemons[&daemon_id];
+                    // kill_tx was taken by the stop handler; the reaper then
+                    // consumed the receiver and exited. There is no direct
+                    // "reaper finished" flag, but the child log file will
+                    // have the Exit message written after wait() returns.
+                    entry.kill_tx.is_none() && entry.status == DaemonStatus::Killed
+                };
+                if reaped {
+                    // Extra: briefly confirm the log file now contains an Exit line.
+                    let log_path = {
+                        let daemons = state.daemons.lock().await;
+                        daemons[&daemon_id].log_path.clone()
+                    };
+                    for _ in 0..200 {
+                        if let Ok(bytes) = tokio::fs::read(&log_path).await
+                            && String::from_utf8_lossy(&bytes).contains("\"Exit\"")
+                        {
+                            return;
+                        }
+                        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                    }
+                    panic!("reaper ran but never wrote Exit to the log file");
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            panic!("daemon '{}' kill_tx was never consumed", daemon_id);
+        }
+
+        #[tokio::test]
+        async fn stop_running_daemon_is_idempotent() {
+            // Calling /daemon/stop twice on the same daemon must not panic
+            // and must keep returning 200 OK. The second call finds the
+            // daemon in status Killed and short-circuits to ok:true.
+            let dir = TempDir::new().unwrap();
+            let state = make_state(dir.path());
+            pre_allow(dir.path(), dir.path(), "sleep 60");
+            let router = make_router(state.clone());
+
+            let start_resp = router
+                .oneshot(json_req(
+                    "/daemon/start",
+                    "key1",
+                    serde_json::json!({"project_id": "proj1", "command": "sleep 60"}),
+                ))
+                .await
+                .unwrap();
+            let daemon_id = to_json(start_resp).await["daemon_id"]
+                .as_str()
+                .unwrap()
+                .to_string();
+
+            for _ in 0..2 {
+                let resp = make_router(state.clone())
+                    .oneshot(json_req(
+                        "/daemon/stop",
+                        "key1",
+                        serde_json::json!({
+                            "project_id": "proj1",
+                            "daemon_id": daemon_id.clone(),
+                        }),
+                    ))
+                    .await
+                    .unwrap();
+                assert_eq!(resp.status(), axum::http::StatusCode::OK);
+            }
+        }
+
         // ── POST /daemon/stop-all ─────────────────────────────────────────────
 
         #[tokio::test]
@@ -1769,7 +1914,7 @@ mod tests {
                     command: "my-command".to_string(),
                     started_at: std::time::UNIX_EPOCH + std::time::Duration::from_secs(5000),
                     status: DaemonStatus::Finished { exit_code: 2 },
-                    pid: None,
+                    kill_tx: None,
                     log_path: dir.path().join("d1.log"),
                 },
             );

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -116,7 +116,15 @@ fn is_server_process_alive(pid: u32, expected_exe: Option<&str>) -> bool {
     #[cfg(target_os = "linux")]
     {
         match std::fs::read_link(format!("/proc/{}/exe", pid)) {
-            Ok(target) => target.to_string_lossy() == expected,
+            Ok(target) => {
+                let target_str = target.to_string_lossy();
+                // When the running binary is replaced on disk (e.g. `cargo install`
+                // over the same path), the kernel appends " (deleted)" to the symlink
+                // target. Strip it before comparing so we don't falsely kill a still-
+                // valid server process.
+                let target_str = target_str.strip_suffix(" (deleted)").unwrap_or(&target_str);
+                target_str == expected
+            }
             Err(_) => false, // /proc entry gone → process is dead or inaccessible
         }
     }

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -18,6 +18,14 @@ pub const MCP_PORT: u16 = 7822;
 #[derive(Serialize, Deserialize, Default)]
 struct ServerState {
     pub pid: Option<u32>,
+    /// Path of the executable that was spawned for this server.
+    /// Used to verify (on Linux via /proc/<pid>/exe) that the PID we
+    /// loaded from disk still references our binary and has not been
+    /// recycled by the kernel to an unrelated process. Optional for
+    /// backwards compatibility with server state files written by
+    /// prior versions.
+    #[serde(default)]
+    pub exe_path: Option<String>,
 }
 
 /// Per-project state stored in ~/.ai-pod/{hash}.json
@@ -85,6 +93,43 @@ fn is_process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 
+/// Verify that the process at `pid` is still the same binary we spawned.
+///
+/// Returns true if the process is alive AND (on Linux) its `/proc/<pid>/exe`
+/// symlink target matches `expected_exe`. On non-Linux platforms, or when
+/// `expected_exe` is `None` (e.g. loaded from a server.json file written by
+/// a prior CLI version), falls back to a plain liveness check.
+///
+/// This closes a PID-reuse correctness gap in `ensure_shared_server`: after
+/// the shared server exits, a stale PID in `server.json` could otherwise
+/// pass `kill(pid, 0)` if the kernel recycled the PID to an unrelated
+/// process, causing us to skip the restart. No signals are sent here.
+fn is_server_process_alive(pid: u32, expected_exe: Option<&str>) -> bool {
+    if !is_process_alive(pid) {
+        return false;
+    }
+    let expected = match expected_exe {
+        Some(p) => p,
+        None => return true, // backwards-compat: no identity info stored
+    };
+
+    #[cfg(target_os = "linux")]
+    {
+        match std::fs::read_link(format!("/proc/{}/exe", pid)) {
+            Ok(target) => target.to_string_lossy() == expected,
+            Err(_) => false, // /proc entry gone → process is dead or inaccessible
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = expected;
+        // macOS has no /proc. Fall back to liveness-only; this is a
+        // correctness gap, not a security one, since no signal is sent.
+        true
+    }
+}
+
 /// Create the shared server log file with owner-only permissions (0o600).
 /// Truncates any existing file, matching `File::create` semantics, so each
 /// shared-server start gets a fresh log.
@@ -111,10 +156,10 @@ pub fn ensure_shared_server(config: &AppConfig) -> Result<()> {
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_default();
 
-    if let Some(pid) = state.pid {
-        if is_process_alive(pid) {
-            return Ok(());
-        }
+    if let Some(pid) = state.pid
+        && is_server_process_alive(pid, state.exe_path.as_deref())
+    {
+        return Ok(());
     }
 
     let exe = std::env::current_exe().context("Failed to get current executable path")?;
@@ -131,7 +176,10 @@ pub fn ensure_shared_server(config: &AppConfig) -> Result<()> {
         .context("Failed to spawn shared server")?;
 
     let pid = child.id();
-    let new_state = ServerState { pid: Some(pid) };
+    let new_state = ServerState {
+        pid: Some(pid),
+        exe_path: Some(exe.to_string_lossy().to_string()),
+    };
     let json = serde_json::to_string_pretty(&new_state)?;
     let mut file = OpenOptions::new()
         .write(true)

--- a/src/server/rest.rs
+++ b/src/server/rest.rs
@@ -4,41 +4,12 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
-use futures_util::{Stream, StreamExt};
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
-
-struct KillOnDrop(Option<u32>);
-
-impl Drop for KillOnDrop {
-    fn drop(&mut self) {
-        if let Some(pid) = self.0 {
-            if pid > 0 {
-                // Kill the entire process group to catch children of sh
-                unsafe {
-                    libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
-                }
-            }
-        }
-    }
-}
-
-struct GuardedStream<S: Unpin> {
-    inner: S,
-    _guard: KillOnDrop,
-}
-
-impl<S: Stream + Unpin> Stream for GuardedStream<S> {
-    type Item = S::Item;
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.inner).poll_next(cx)
-    }
-}
 
 use subtle::ConstantTimeEq;
 
@@ -160,7 +131,6 @@ pub async fn run_command_handler(
         }
     };
 
-    let pid = child.id();
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
 
@@ -205,22 +175,48 @@ pub async fn run_command_handler(
     });
 
     tokio::spawn(async move {
-        let exit_code = match child.wait().await {
-            Ok(status) => status.code().unwrap_or(-1),
-            Err(_) => -1,
+        // Own `child` throughout. The kernel cannot recycle the PID
+        // until `Child::wait()` returns, so `child.id()` in the
+        // client-disconnect branch is guaranteed to still reference our
+        // process group. This eliminates the PID-reuse TOCTOU that
+        // motivated issue #29.
+        let exit_code = tokio::select! {
+            res = child.wait() => {
+                match res {
+                    Ok(status) => status.code().unwrap_or(-1),
+                    Err(_) => -1,
+                }
+            }
+            // Resolves when the axum response body (and hence the mpsc
+            // Receiver held by ReceiverStream) is dropped — client
+            // disconnect or early cancel. `closed()` is cancel-safe.
+            _ = tx.closed() => {
+                if let Some(pid) = child.id()
+                    && pid > 0
+                {
+                    // Kill the whole process group (see
+                    // `.process_group(0)` on spawn) so children of
+                    // `sh` are caught too.
+                    unsafe {
+                        libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
+                    }
+                }
+                match child.wait().await {
+                    Ok(status) => status.code().unwrap_or(-1),
+                    Err(_) => -1,
+                }
+            }
         };
         // Wait for both reader tasks to finish before sending Exit,
         // ensuring Exit is always the last message in the channel.
         let _ = stdout_done_rx.await;
         let _ = stderr_done_rx.await;
         let msg = serde_json::to_string(&Message::Exit(exit_code)).unwrap() + "\n";
+        // On the client-disconnect path, tx.send will Err and we move on.
         let _ = tx.send(msg).await;
     });
 
-    let stream = GuardedStream {
-        inner: ReceiverStream::new(rx).map(|s| Ok::<_, std::convert::Infallible>(s)),
-        _guard: KillOnDrop(pid),
-    };
+    let stream = ReceiverStream::new(rx).map(|s| Ok::<_, std::convert::Infallible>(s));
     axum::body::Body::from_stream(stream).into_response()
 }
 

--- a/src/server/rest.rs
+++ b/src/server/rest.rs
@@ -197,13 +197,28 @@ pub async fn run_command_handler(
                     // Kill the whole process group (see
                     // `.process_group(0)` on spawn) so children of
                     // `sh` are caught too.
-                    unsafe {
-                        libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
+                    let ret = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGTERM) };
+                    debug_assert_eq!(ret, 0, "kill({}, SIGTERM) failed: {}", pid, std::io::Error::last_os_error());
+                    // Give the process group a grace period, then escalate to SIGKILL
+                    // to handle processes that ignore SIGTERM.
+                    tokio::select! {
+                        res = child.wait() => match res {
+                            Ok(status) => status.code().unwrap_or(-1),
+                            Err(_) => -1,
+                        },
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                            let _ = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+                            match child.wait().await {
+                                Ok(status) => status.code().unwrap_or(-1),
+                                Err(_) => -1,
+                            }
+                        }
                     }
-                }
-                match child.wait().await {
-                    Ok(status) => status.code().unwrap_or(-1),
-                    Err(_) => -1,
+                } else {
+                    match child.wait().await {
+                        Ok(status) => status.code().unwrap_or(-1),
+                        Err(_) => -1,
+                    }
                 }
             }
         };


### PR DESCRIPTION
## Summary

This PR eliminates PID-reuse time-of-check-time-of-use (TOCTOU) vulnerabilities in daemon lifecycle management and command execution by ensuring the process owner holds the PID until after `wait()` completes, preventing the kernel from recycling it to an unrelated process.

## Key Changes

- **Daemon lifecycle refactoring**: Replace direct PID storage (`pid: Option<u32>`) with a `tokio::sync::oneshot::Sender` (`kill_tx`) that routes kill requests through the reaper task. This ensures the reaper—which owns the `Child` handle—controls when `wait()` is called, preventing PID recycling between the stop request and actual termination.

- **Reaper task enhancement**: Implement `tokio::select!` to wait for either natural child exit or a kill signal via the oneshot channel. When a kill signal arrives, the reaper sends SIGTERM to the process group and then calls `wait()`, closing the PID-reuse window.

- **Command handler fix**: Replace the `GuardedStream` / `KillOnDrop` mechanism with a similar `tokio::select!` pattern in `run_command_handler`. The spawned task now owns `child` and waits for either natural exit or client disconnect (via `tx.closed()`), ensuring the PID cannot be recycled while the handler is still alive.

- **Server lifecycle verification**: Add `exe_path` field to `ServerState` and implement `is_server_process_alive()` to verify that a PID loaded from disk still references the same binary. On Linux, this checks `/proc/<pid>/exe`; on other platforms it falls back to liveness-only checks for backwards compatibility.

- **Test coverage**: Add two new integration tests:
  - `stop_terminates_long_running_child`: Verifies that stop requests actually terminate long-running processes via the oneshot mechanism
  - `stop_running_daemon_is_idempotent`: Confirms that calling stop twice on the same daemon is safe and idempotent

## Implementation Details

- The oneshot channel is created before the reaper task spawns, ensuring the sender is always available when needed
- Stop handlers (`stop_daemon_handler` and `stop_all_daemons_for_project`) take ownership of the sender via `.take()`, making subsequent stops graceful no-ops
- The reaper's status-update logic preserves `Killed` status even if the child exited naturally, maintaining consistency
- Process groups are used (via `.process_group(0)` on spawn) to ensure children of shell commands are also terminated
- All unsafe `libc::kill` calls are guarded by PID validity checks (`pid > 0`)

https://claude.ai/code/session_01XRJbHRs1j3amXgCUHgmFRx