### PR TITLE
Add dry-run mode to preview container commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,10 @@ pub struct Cli {
     /// Value for --userns passed to podman run (default: keep-id)
     #[arg(long, default_value = "keep-id")]
     pub userns: String,
+
+    /// Print podman/docker commands instead of executing them
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/container.rs
+++ b/src/container.rs
@@ -750,6 +750,7 @@ mod tests {
     fn test_runtime() -> ContainerRuntime {
         ContainerRuntime {
             kind: RuntimeKind::Podman,
+            dry_run: false,
         }
     }
 
@@ -902,6 +903,7 @@ mod tests {
         let config = make_test_config(&dir);
         let rt = ContainerRuntime {
             kind: RuntimeKind::Docker,
+            dry_run: false,
         };
         generate_runtime_claude_md(&rt, &config).unwrap();
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn needs_build_returns_true_when_force() {
         use crate::runtime::{ContainerRuntime, RuntimeKind};
-        let rt = ContainerRuntime { kind: RuntimeKind::Podman };
+        let rt = ContainerRuntime { kind: RuntimeKind::Podman, dry_run: false };
         assert!(needs_build(&rt, "any-image", true).unwrap());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ async fn main() -> Result<()> {
     }
 
     // Detect container runtime (podman preferred, docker fallback)
-    let rt = ContainerRuntime::detect()?;
+    let rt = ContainerRuntime::detect(cli.dry_run)?;
 
     match &cli.command {
         Some(Command::Build) => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,12 +10,13 @@ pub enum RuntimeKind {
 #[derive(Debug, Clone)]
 pub struct ContainerRuntime {
     pub kind: RuntimeKind,
+    pub dry_run: bool,
 }
 
 impl ContainerRuntime {
     /// Detect which container runtime is available.
     /// Prefers podman; falls back to docker.
-    pub fn detect() -> Result<Self> {
+    pub fn detect(dry_run: bool) -> Result<Self> {
         if Command::new("podman")
             .arg("--version")
             .output()
@@ -23,6 +24,7 @@ impl ContainerRuntime {
         {
             return Ok(Self {
                 kind: RuntimeKind::Podman,
+                dry_run,
             });
         }
         if Command::new("docker")
@@ -32,6 +34,7 @@ impl ContainerRuntime {
         {
             return Ok(Self {
                 kind: RuntimeKind::Docker,
+                dry_run,
             });
         }
         anyhow::bail!(
@@ -48,13 +51,28 @@ impl ContainerRuntime {
     }
 
     /// Returns a std::process::Command with the runtime binary.
+    /// When `dry_run` is set, returns an `echo` command prefixed with the
+    /// runtime name so the intended invocation is printed instead of run.
     pub fn command(&self) -> Command {
-        Command::new(self.cmd())
+        if self.dry_run {
+            let mut cmd = Command::new("echo");
+            cmd.arg(self.cmd());
+            cmd
+        } else {
+            Command::new(self.cmd())
+        }
     }
 
     /// Returns a tokio::process::Command with the runtime binary.
+    /// Honors `dry_run` the same way as `command()`.
     pub fn async_command(&self) -> tokio::process::Command {
-        tokio::process::Command::new(self.cmd())
+        if self.dry_run {
+            let mut cmd = tokio::process::Command::new("echo");
+            cmd.arg(self.cmd());
+            cmd
+        } else {
+            tokio::process::Command::new(self.cmd())
+        }
     }
 
     /// The hostname that resolves to the host from inside a container.
@@ -92,6 +110,7 @@ mod tests {
     fn podman_runtime_properties() {
         let rt = ContainerRuntime {
             kind: RuntimeKind::Podman,
+            dry_run: false,
         };
         assert_eq!(rt.cmd(), "podman");
         assert_eq!(rt.host_gateway(), "host.containers.internal");
@@ -104,11 +123,51 @@ mod tests {
     fn docker_runtime_properties() {
         let rt = ContainerRuntime {
             kind: RuntimeKind::Docker,
+            dry_run: false,
         };
         assert_eq!(rt.cmd(), "docker");
         assert_eq!(rt.host_gateway(), "host.docker.internal");
         assert_eq!(rt.add_host_arg(), "--add-host=host.docker.internal:host-gateway");
         assert_eq!(rt.server_url(), "http://host.docker.internal:7822");
         assert_eq!(rt.display_name(), "Docker");
+    }
+
+    #[test]
+    fn dry_run_command_echoes_invocation() {
+        let rt = ContainerRuntime {
+            kind: RuntimeKind::Podman,
+            dry_run: true,
+        };
+        let output = rt
+            .command()
+            .args(["run", "--rm", "alpine", "true"])
+            .output()
+            .expect("echo should execute");
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("podman run --rm alpine true"),
+            "stdout should contain the full podman invocation, got: {stdout}"
+        );
+    }
+
+    #[test]
+    fn dry_run_off_uses_real_binary() {
+        let rt = ContainerRuntime {
+            kind: RuntimeKind::Docker,
+            dry_run: false,
+        };
+        let program = rt.command().get_program().to_string_lossy().into_owned();
+        assert_eq!(program, "docker");
+    }
+
+    #[test]
+    fn dry_run_on_uses_echo() {
+        let rt = ContainerRuntime {
+            kind: RuntimeKind::Podman,
+            dry_run: true,
+        };
+        let program = rt.command().get_program().to_string_lossy().into_owned();
+        assert_eq!(program, "echo");
     }
 }

--- a/src/server/daemons.rs
+++ b/src/server/daemons.rs
@@ -695,6 +695,7 @@ mod tests {
             daemons: Arc::new(Mutex::new(HashMap::new())),
             runtime: crate::runtime::ContainerRuntime {
                 kind: crate::runtime::RuntimeKind::Podman,
+                dry_run: false,
             },
         }
     }
@@ -1267,6 +1268,7 @@ mod tests {
                 daemons: Arc::new(Mutex::new(std::collections::HashMap::new())),
                 runtime: crate::runtime::ContainerRuntime {
                     kind: crate::runtime::RuntimeKind::Podman,
+                    dry_run: false,
                 },
             };
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -26,7 +26,7 @@ lazy_static! {
     /// `None` means no runtime is available on this machine; tests that
     /// require one skip via `try_runtime()`.
     static ref RT: Option<Mutex<ContainerRuntime>> = {
-        let rt = ContainerRuntime::detect().ok()?;
+        let rt = ContainerRuntime::detect(false).ok()?;
         // detect() only checks `--version`; probe `info` to confirm the
         // daemon is actually running.
         let ok = rt

--- a/tests/rate_limit.rs
+++ b/tests/rate_limit.rs
@@ -22,6 +22,7 @@ fn make_state(config_dir: &std::path::Path) -> AppState {
         daemons: Arc::new(Mutex::new(HashMap::new())),
         runtime: ContainerRuntime {
             kind: RuntimeKind::Podman,
+            dry_run: false,
         },
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a `--dry-run` flag that allows users to preview container runtime commands without executing them. When enabled, commands are echoed to stdout instead of being executed.

## Key Changes
- Added `dry_run: bool` field to `ContainerRuntime` struct
- Updated `ContainerRuntime::detect()` to accept and store the `dry_run` parameter
- Modified `command()` and `async_command()` methods to return `echo` commands when `dry_run` is enabled, prefixed with the runtime name (podman/docker)
- Added `--dry-run` CLI flag to the `Cli` struct
- Wired the CLI flag through to `ContainerRuntime::detect()` in `main()`
- Updated all test fixtures and test code to initialize the new `dry_run` field

## Implementation Details
- When `dry_run` is true, both sync and async command builders return an `echo` command that prints the intended invocation instead of executing it
- The runtime binary name is passed as the first argument to `echo`, so the full command is visible in the output
- Added comprehensive tests covering:
  - Dry-run mode echoing the full invocation
  - Dry-run off using the real binary
  - Dry-run on using echo
- All existing tests updated to explicitly set `dry_run: false` to maintain current behavior

https://claude.ai/code/session_013PxtCSMBrLsJei9ZncyJhq