### PR TITLE
Standardize container user to ai-pod with hardcoded home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The default image is based on Ubuntu and installs Claude Code via the official i
 
 ## Host interaction
 
-The `host-tools` binary is installed in every container at `/home/claude/.local/bin/host-tools`. Claude is taught to use it via a skill file that is automatically installed in each container.
+The `host-tools` binary is installed in every container at `/home/ai-pod/.local/bin/host-tools`. Claude is taught to use it via a skill file that is automatically installed in each container.
 
 ### host-tools run-command
 

--- a/ai-pod.Dockerfile
+++ b/ai-pod.Dockerfile
@@ -8,16 +8,16 @@ RUN host-tools install claude
 
 WORKDIR /app
 
-RUN useradd -u 1000 -ms /bin/bash claude
-RUN chown -R claude /app
+RUN useradd -ms /bin/bash ai-pod
+RUN chown -R ai-pod /app
 
 # System-level git identity
-RUN git config --system user.email "claude@ai-pod" && \
-    git config --system user.name "claude"
+RUN git config --system user.email "ai-pod@ai-pod" && \
+    git config --system user.name "ai-pod"
 
-USER claude
+USER ai-pod
 
-ENV PATH="/home/claude/.local/bin:${PATH}"
+ENV PATH="/home/ai-pod/.local/bin:${PATH}"
 
 
 CMD ["claude"]

--- a/src/container.rs
+++ b/src/container.rs
@@ -185,33 +185,17 @@ fn write_gitconfig_to_volume(
     Ok(())
 }
 
-/// Initialize a named home volume for the first time.
-fn init_home_volume(
+/// Populate a home volume via a temporary stopped container.
+/// Handles directory creation, runtime config, skill file, opencode config, and git identity.
+/// Set `copy_claude_json` to copy `~/.claude.json` (first-time init only; skipped on reseed).
+fn seed_home_volume(
     rt: &ContainerRuntime,
     config: &AppConfig,
     volume_name: &str,
     container_name: &str,
     image: &str,
-    project_id: &str,
-    api_key: &str,
+    copy_claude_json: bool,
 ) -> Result<()> {
-    println!(
-        "{} {}",
-        "Initialising home volume:".blue().bold(),
-        volume_name
-    );
-
-    // 1. Create the volume
-    let status = rt
-        .command()
-        .args(["volume", "create", volume_name])
-        .status()
-        .context("Failed to create volume")?;
-    if !status.success() {
-        anyhow::bail!("Failed to create volume {}", volume_name);
-    }
-
-    // 2. Create a stopped container for cp operations.
     let init_container = format!("{}-init", container_name);
     let status = rt
         .command()
@@ -230,20 +214,20 @@ fn init_home_volume(
         anyhow::bail!("Failed to create init container");
     }
 
-    // 3. Copy ~/.claude.json (soft error — auth state)
-    let claude_json = config.home_dir.join(".claude.json");
-    if claude_json.exists() {
-        let _ = rt
-            .command()
-            .args([
-                "cp",
-                &claude_json.to_string_lossy(),
-                &format!("{}:{}/", init_container, CONTAINER_HOME),
-            ])
-            .status();
+    if copy_claude_json {
+        let claude_json = config.home_dir.join(".claude.json");
+        if claude_json.exists() {
+            let _ = rt
+                .command()
+                .args([
+                    "cp",
+                    &claude_json.to_string_lossy(),
+                    &format!("{}:{}/", init_container, CONTAINER_HOME),
+                ])
+                .status();
+        }
     }
 
-    // 3b. Ensure required directories exist in the volume.
     let _ = rt
         .command()
         .args([
@@ -260,7 +244,6 @@ fn init_home_volume(
         ])
         .status();
 
-    // 4. Generate and copy runtime config
     generate_runtime_claude_md(rt, config)?;
     generate_runtime_settings(config)?;
 
@@ -282,7 +265,6 @@ fn init_home_volume(
         ])
         .status();
 
-    // 5. Copy skill file
     let skill_path = config.config_dir.join("skill.md");
     std::fs::write(&skill_path, SKILL_MD)?;
     let _ = rt
@@ -297,7 +279,6 @@ fn init_home_volume(
         ])
         .status();
 
-    // 6. Copy opencode config if present on host
     let opencode_config = config.home_dir.join(".config").join("opencode");
     if opencode_config.exists() {
         let _ = rt
@@ -310,11 +291,39 @@ fn init_home_volume(
             .status();
     }
 
-    // 7. Copy host git identity into the volume
     write_gitconfig_to_volume(rt, config, &init_container)?;
 
-    // 8. Remove init container
     let _ = rt.command().args(["rm", &init_container]).status();
+
+    Ok(())
+}
+
+/// Initialize a named home volume for the first time.
+fn init_home_volume(
+    rt: &ContainerRuntime,
+    config: &AppConfig,
+    volume_name: &str,
+    container_name: &str,
+    image: &str,
+    project_id: &str,
+    api_key: &str,
+) -> Result<()> {
+    println!(
+        "{} {}",
+        "Initialising home volume:".blue().bold(),
+        volume_name
+    );
+
+    let status = rt
+        .command()
+        .args(["volume", "create", volume_name])
+        .status()
+        .context("Failed to create volume")?;
+    if !status.success() {
+        anyhow::bail!("Failed to create volume {}", volume_name);
+    }
+
+    seed_home_volume(rt, config, volume_name, container_name, image, true)?;
 
     let _ = (project_id, api_key); // used via env vars at runtime
 
@@ -340,97 +349,7 @@ fn reseed_home_volume(
         volume_name
     );
 
-    // 1. Create a stopped container for cp operations.
-    let init_container = format!("{}-init", container_name);
-    let status = rt
-        .command()
-        .args([
-            "create",
-            "--name",
-            &init_container,
-            "-v",
-            &format!("{}:{}", volume_name, CONTAINER_HOME),
-            image,
-            "true",
-        ])
-        .status()
-        .context("Failed to create init container for reseed")?;
-    if !status.success() {
-        anyhow::bail!("Failed to create init container for reseed");
-    }
-
-    // 2. Ensure required directories exist in the volume.
-    let _ = rt
-        .command()
-        .args([
-            "run",
-            "--rm",
-            "-v",
-            &format!("{}:{}:z", volume_name, CONTAINER_HOME),
-            image,
-            "mkdir",
-            "-p",
-            &format!("{}/.claude", CONTAINER_HOME),
-            &format!("{}/.claude/skills/ai-pod", CONTAINER_HOME),
-            &format!("{}/.config", CONTAINER_HOME),
-        ])
-        .status();
-
-    // 2b. Regenerate and copy runtime config (refreshes hooks + permissions)
-    generate_runtime_claude_md(rt, config)?;
-    generate_runtime_settings(config)?;
-
-    let _ = rt
-        .command()
-        .args([
-            "cp",
-            &config.runtime_settings.to_string_lossy(),
-            &format!("{}:{}/.claude/settings.json", init_container, CONTAINER_HOME),
-        ])
-        .status();
-
-    let _ = rt
-        .command()
-        .args([
-            "cp",
-            &config.runtime_claude_md.to_string_lossy(),
-            &format!("{}:{}/.claude/CLAUDE.md", init_container, CONTAINER_HOME),
-        ])
-        .status();
-
-    // 3. Copy skill file
-    let skill_path = config.config_dir.join("skill.md");
-    std::fs::write(&skill_path, SKILL_MD)?;
-    let _ = rt
-        .command()
-        .args([
-            "cp",
-            skill_path.to_str().unwrap(),
-            &format!(
-                "{}:{}/.claude/skills/ai-pod/SKILL.md",
-                init_container, CONTAINER_HOME
-            ),
-        ])
-        .status();
-
-    // 4. Copy opencode config if present on host
-    let opencode_config = config.home_dir.join(".config").join("opencode");
-    if opencode_config.exists() {
-        let _ = rt
-            .command()
-            .args([
-                "cp",
-                &opencode_config.to_string_lossy(),
-                &format!("{}:{}/.config/", init_container, CONTAINER_HOME),
-            ])
-            .status();
-    }
-
-    // 5. Copy host git identity into the volume
-    write_gitconfig_to_volume(rt, config, &init_container)?;
-
-    // 6. Remove init container
-    let _ = rt.command().args(["rm", &init_container]).status();
+    seed_home_volume(rt, config, volume_name, container_name, image, false)?;
 
     let _ = (project_id, api_key); // used via env vars at runtime
 
@@ -561,7 +480,11 @@ pub fn run_in_container(
         command
     );
 
-    let mut run_args: Vec<String> = vec!["run".into(), "--rm".into(), "-it".into()];
+    let mut run_args: Vec<String> = vec![
+        "run".into(),
+        "--rm".into(),
+        "-it".into(),
+    ];
     run_args.extend_from_slice(&[
         "--label".into(),
         "managed-by=ai-pod".into(),
@@ -615,9 +538,9 @@ pub fn list_containers(rt: &ContainerRuntime) -> Result<()> {
         .context("Failed to list containers")?;
 
     if output.stdout.is_empty() {
-        println!("{}", "No claude containers found.".yellow());
+        println!("{}", "No ai-pod containers found.".yellow());
     } else {
-        println!("{}", "Claude containers:".blue().bold());
+        println!("{}", "ai-pod containers:".blue().bold());
         println!("{:<20} {:<30} {}", "NAME", "STATUS", "CREATED");
         println!("{}", "-".repeat(80));
         print!("{}", String::from_utf8_lossy(&output.stdout));
@@ -627,7 +550,7 @@ pub fn list_containers(rt: &ContainerRuntime) -> Result<()> {
 }
 
 pub fn attach_container(rt: &ContainerRuntime) -> Result<()> {
-    // List all running claude containers with their start times
+    // List all running ai-pod containers with their start times
     let output = rt
         .command()
         .args([
@@ -652,7 +575,7 @@ pub fn attach_container(rt: &ContainerRuntime) -> Result<()> {
         .collect();
 
     if entries.is_empty() {
-        println!("{}", "No running claude containers found.".yellow());
+        println!("{}", "No running ai-pod containers found.".yellow());
         return Ok(());
     }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -27,6 +27,11 @@ fn container_claude_md(rt: &ContainerRuntime) -> String {
 
 const SKILL_MD: &str = include_str!("../templates/skill.md");
 
+/// Home directory of the `ai-pod` user inside every container image.
+/// The Dockerfile template creates this user with this home path, so the
+/// runtime does not need to probe the image.
+const CONTAINER_HOME: &str = "/home/ai-pod";
+
 pub fn containers_for_prefix(
     rt: &ContainerRuntime,
     prefix: &str,
@@ -135,18 +140,6 @@ fn generate_runtime_settings(config: &AppConfig) -> Result<()> {
     Ok(())
 }
 
-/// Detect the home directory of the default user in a container image.
-fn detect_container_home(rt: &ContainerRuntime, image: &str) -> String {
-    rt.command()
-        .args(["run", "--rm", image, "sh", "-c", "echo $HOME"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "/root".to_string())
-}
-
 fn read_git_global(key: &str) -> Option<String> {
     std::process::Command::new("git")
         .args(["config", "--global", key])
@@ -164,7 +157,6 @@ fn write_gitconfig_to_volume(
     rt: &ContainerRuntime,
     config: &AppConfig,
     init_container: &str,
-    home_dir: &str,
 ) -> Result<()> {
     let name = read_git_global("user.name");
     let email = read_git_global("user.email");
@@ -187,7 +179,7 @@ fn write_gitconfig_to_volume(
         .args([
             "cp",
             tmp.to_str().unwrap(),
-            &format!("{}:{}/.gitconfig", init_container, home_dir),
+            &format!("{}:{}/.gitconfig", init_container, CONTAINER_HOME),
         ])
         .status();
     Ok(())
@@ -202,7 +194,6 @@ fn init_home_volume(
     image: &str,
     project_id: &str,
     api_key: &str,
-    home_dir: &str,
 ) -> Result<()> {
     println!(
         "{} {}",
@@ -229,7 +220,7 @@ fn init_home_volume(
             "--name",
             &init_container,
             "-v",
-            &format!("{}:{}", volume_name, home_dir),
+            &format!("{}:{}", volume_name, CONTAINER_HOME),
             image,
             "true",
         ])
@@ -247,7 +238,7 @@ fn init_home_volume(
             .args([
                 "cp",
                 &claude_json.to_string_lossy(),
-                &format!("{}:{}/", init_container, home_dir),
+                &format!("{}:{}/", init_container, CONTAINER_HOME),
             ])
             .status();
     }
@@ -259,13 +250,13 @@ fn init_home_volume(
             "run",
             "--rm",
             "-v",
-            &format!("{}:{}:z", volume_name, home_dir),
+            &format!("{}:{}:z", volume_name, CONTAINER_HOME),
             image,
             "mkdir",
             "-p",
-            &format!("{}/.claude", home_dir),
-            &format!("{}/.claude/skills/ai-pod", home_dir),
-            &format!("{}/.config", home_dir),
+            &format!("{}/.claude", CONTAINER_HOME),
+            &format!("{}/.claude/skills/ai-pod", CONTAINER_HOME),
+            &format!("{}/.config", CONTAINER_HOME),
         ])
         .status();
 
@@ -278,7 +269,7 @@ fn init_home_volume(
         .args([
             "cp",
             &config.runtime_settings.to_string_lossy(),
-            &format!("{}:{}/.claude/settings.json", init_container, home_dir),
+            &format!("{}:{}/.claude/settings.json", init_container, CONTAINER_HOME),
         ])
         .status();
 
@@ -287,7 +278,7 @@ fn init_home_volume(
         .args([
             "cp",
             &config.runtime_claude_md.to_string_lossy(),
-            &format!("{}:{}/.claude/CLAUDE.md", init_container, home_dir),
+            &format!("{}:{}/.claude/CLAUDE.md", init_container, CONTAINER_HOME),
         ])
         .status();
 
@@ -301,7 +292,7 @@ fn init_home_volume(
             skill_path.to_str().unwrap(),
             &format!(
                 "{}:{}/.claude/skills/ai-pod/SKILL.md",
-                init_container, home_dir
+                init_container, CONTAINER_HOME
             ),
         ])
         .status();
@@ -314,13 +305,13 @@ fn init_home_volume(
             .args([
                 "cp",
                 &opencode_config.to_string_lossy(),
-                &format!("{}:{}/.config/", init_container, home_dir),
+                &format!("{}:{}/.config/", init_container, CONTAINER_HOME),
             ])
             .status();
     }
 
     // 7. Copy host git identity into the volume
-    write_gitconfig_to_volume(rt, config, &init_container, home_dir)?;
+    write_gitconfig_to_volume(rt, config, &init_container)?;
 
     // 8. Remove init container
     let _ = rt.command().args(["rm", &init_container]).status();
@@ -342,7 +333,6 @@ fn reseed_home_volume(
     image: &str,
     project_id: &str,
     api_key: &str,
-    home_dir: &str,
 ) -> Result<()> {
     println!(
         "{} {}",
@@ -359,7 +349,7 @@ fn reseed_home_volume(
             "--name",
             &init_container,
             "-v",
-            &format!("{}:{}", volume_name, home_dir),
+            &format!("{}:{}", volume_name, CONTAINER_HOME),
             image,
             "true",
         ])
@@ -376,13 +366,13 @@ fn reseed_home_volume(
             "run",
             "--rm",
             "-v",
-            &format!("{}:{}:z", volume_name, home_dir),
+            &format!("{}:{}:z", volume_name, CONTAINER_HOME),
             image,
             "mkdir",
             "-p",
-            &format!("{}/.claude", home_dir),
-            &format!("{}/.claude/skills/ai-pod", home_dir),
-            &format!("{}/.config", home_dir),
+            &format!("{}/.claude", CONTAINER_HOME),
+            &format!("{}/.claude/skills/ai-pod", CONTAINER_HOME),
+            &format!("{}/.config", CONTAINER_HOME),
         ])
         .status();
 
@@ -395,7 +385,7 @@ fn reseed_home_volume(
         .args([
             "cp",
             &config.runtime_settings.to_string_lossy(),
-            &format!("{}:{}/.claude/settings.json", init_container, home_dir),
+            &format!("{}:{}/.claude/settings.json", init_container, CONTAINER_HOME),
         ])
         .status();
 
@@ -404,7 +394,7 @@ fn reseed_home_volume(
         .args([
             "cp",
             &config.runtime_claude_md.to_string_lossy(),
-            &format!("{}:{}/.claude/CLAUDE.md", init_container, home_dir),
+            &format!("{}:{}/.claude/CLAUDE.md", init_container, CONTAINER_HOME),
         ])
         .status();
 
@@ -418,7 +408,7 @@ fn reseed_home_volume(
             skill_path.to_str().unwrap(),
             &format!(
                 "{}:{}/.claude/skills/ai-pod/SKILL.md",
-                init_container, home_dir
+                init_container, CONTAINER_HOME
             ),
         ])
         .status();
@@ -431,13 +421,13 @@ fn reseed_home_volume(
             .args([
                 "cp",
                 &opencode_config.to_string_lossy(),
-                &format!("{}:{}/.config/", init_container, home_dir),
+                &format!("{}:{}/.config/", init_container, CONTAINER_HOME),
             ])
             .status();
     }
 
     // 5. Copy host git identity into the volume
-    write_gitconfig_to_volume(rt, config, &init_container, home_dir)?;
+    write_gitconfig_to_volume(rt, config, &init_container)?;
 
     // 6. Remove init container
     let _ = rt.command().args(["rm", &init_container]).status();
@@ -461,7 +451,6 @@ pub fn launch_container(
     let prefix = container_prefix(workspace);
     let volume_name = gen_volume_name(workspace);
     let workspace_str = workspace.to_string_lossy();
-    let home_dir = detect_container_home(rt, image);
 
     // On rebuild: stop all existing containers for this workspace and reseed the volume
     if rebuild {
@@ -482,7 +471,6 @@ pub fn launch_container(
                 image,
                 project_id,
                 api_key,
-                &home_dir,
             )?;
         }
     }
@@ -497,7 +485,6 @@ pub fn launch_container(
             image,
             project_id,
             api_key,
-            &home_dir,
         )?;
     }
 
@@ -516,7 +503,7 @@ pub fn launch_container(
         "--label",
         "managed-by=ai-pod",
         "-v",
-        &format!("{}:{}:z", volume_name, home_dir),
+        &format!("{}:{}:z", volume_name, CONTAINER_HOME),
         "-v",
         &format!("{}:/app:Z", workspace_str),
         &add_host,
@@ -553,7 +540,6 @@ pub fn run_in_container(
     let container_name = new_container_name(workspace);
     let volume_name = gen_volume_name(workspace);
     let workspace_str = workspace.to_string_lossy();
-    let home_dir = detect_container_home(rt, image);
 
     // Init home volume if it doesn't exist
     if !volume_exists(rt, &volume_name)? {
@@ -565,7 +551,6 @@ pub fn run_in_container(
             image,
             project_id,
             api_key,
-            &home_dir,
         )?;
     }
 
@@ -581,7 +566,7 @@ pub fn run_in_container(
         "--label".into(),
         "managed-by=ai-pod".into(),
         "-v".into(),
-        format!("{}:{}:z", volume_name, home_dir),
+        format!("{}:{}:z", volume_name, CONTAINER_HOME),
         "-v".into(),
         format!("{}:/app:Z", workspace_str),
         rt.add_host_arg(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,27 +80,27 @@ fn base_image_config(image: &cli::BaseImage) -> BaseImageConfig {
         cli::BaseImage::Alpine => BaseImageConfig {
             from: "alpine:latest",
             install_packages: "RUN apk add --no-cache curl git vim bash",
-            create_user: "RUN adduser -D -h /home/{{AGENT}} {{AGENT}} && chown -R {{AGENT}} /app",
+            create_user: "RUN adduser -D -h /home/ai-pod ai-pod && chown -R ai-pod /app",
         },
         cli::BaseImage::Ubuntu => BaseImageConfig {
             from: "ubuntu:latest",
             install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
-            create_user: "RUN useradd -ms /bin/bash {{AGENT}} && chown -R {{AGENT}} /app",
+            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
         },
         cli::BaseImage::Node => BaseImageConfig {
             from: "node:lts",
             install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
-            create_user: "RUN useradd -ms /bin/bash {{AGENT}} && chown -R {{AGENT}} /app",
+            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
         },
         cli::BaseImage::Rust => BaseImageConfig {
             from: "rust:latest",
             install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
-            create_user: "RUN useradd -ms /bin/bash {{AGENT}} && chown -R {{AGENT}} /app",
+            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
         },
         cli::BaseImage::Python => BaseImageConfig {
             from: "python:latest",
             install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
-            create_user: "RUN useradd -ms /bin/bash {{AGENT}} && chown -R {{AGENT}} /app",
+            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
         },
     }
 }

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -14,12 +14,12 @@ WORKDIR /app
 {{CREATE_USER}}
 
 # System-level git identity (fallback when no host identity is provided)
-RUN git config --system user.email "{{AGENT}}@ai-pod" && \
-    git config --system user.name "{{AGENT}}"
+RUN git config --system user.email "ai-pod@ai-pod" && \
+    git config --system user.name "ai-pod"
 
-USER {{AGENT}}
+USER ai-pod
 
-ENV PATH="/home/{{AGENT}}/.local/bin:${PATH}"
+ENV PATH="/home/ai-pod/.local/bin:${PATH}"
 ENV EDITOR=vim
 
 CMD ["{{AGENT}}"]

--- a/templates/skill.md
+++ b/templates/skill.md
@@ -1,11 +1,11 @@
 ---
 name: ai-pod
-description: This skill should be used when the user asks to run a command on the host machine, open an application on the host, send a desktop notification to the user, list previously approved host commands, or manage long-running background processes (daemons) on the host. Provides the host-tools binary at /home/claude/.local/bin/host-tools.
+description: This skill should be used when the user asks to run a command on the host machine, open an application on the host, send a desktop notification to the user, list previously approved host commands, or manage long-running background processes (daemons) on the host. Provides the host-tools binary at /home/ai-pod/.local/bin/host-tools.
 version: 0.1.0
 ---
 # host-tools — Host Interaction
 
-`/home/claude/.local/bin/host-tools` interacts with the host machine from inside this container.
+`/home/ai-pod/.local/bin/host-tools` interacts with the host machine from inside this container.
 
 ## run-command
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -428,7 +428,7 @@ fn e2e_clean_container_removes_all() {
 
 }
 
-/// Image built from `claude.Dockerfile` has `claude` as the default user.
+/// Image built from the shared Dockerfile has `ai-pod` as the default user.
 #[test]
 fn e2e_container_default_user() {
     let rt = require_runtime!();
@@ -443,8 +443,8 @@ fn e2e_container_default_user() {
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "claude",
-        "default user should be claude"
+        "ai-pod",
+        "default user should be ai-pod"
     );
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -46,11 +46,11 @@ lazy_static! {
 const SHARED_DOCKERFILE: &str = r#"FROM alpine:latest
 RUN apk add --no-cache curl git vim
 WORKDIR /app
-RUN adduser -D claude && chown -R claude /app
-RUN git config --system user.email "claude@ai-pod" && \
-    git config --system user.name "claude"
-USER claude
-ENV PATH="/home/claude/.local/bin:${PATH}"
+RUN adduser -D ai-pod && chown -R ai-pod /app
+RUN git config --system user.email "ai-pod@ai-pod" && \
+    git config --system user.name "ai-pod"
+USER ai-pod
+ENV PATH="/home/ai-pod/.local/bin:${PATH}"
 ENV EDITOR=vim
 "#;
 
@@ -149,11 +149,11 @@ fn make_test_workspace() -> (tempfile::TempDir, std::path::PathBuf) {
         r#"FROM alpine:latest
 RUN apk add --no-cache curl git vim
 WORKDIR /app
-RUN adduser -D claude && chown -R claude /app
-RUN git config --system user.email "claude@ai-pod" && \
-    git config --system user.name "claude"
-USER claude
-ENV PATH="/home/claude/.local/bin:${PATH}"
+RUN adduser -D ai-pod && chown -R ai-pod /app
+RUN git config --system user.email "ai-pod@ai-pod" && \
+    git config --system user.name "ai-pod"
+USER ai-pod
+ENV PATH="/home/ai-pod/.local/bin:${PATH}"
 ENV EDITOR=vim
 "#,
     )


### PR DESCRIPTION
## Summary
This PR standardizes the container user across all Dockerfiles and removes the dynamic home directory detection logic. The container user is now consistently `ai-pod` with a hardcoded home directory of `/home/ai-pod`, eliminating the need for runtime probing.

## Key Changes
- **Removed dynamic home detection**: Deleted the `detect_container_home()` function that previously ran `echo $HOME` inside container images at runtime
- **Introduced constant**: Added `CONTAINER_HOME` constant set to `/home/ai-pod` for use throughout the codebase
- **Simplified function signatures**: Removed `home_dir` parameters from `init_home_volume()`, `reseed_home_volume()`, and `write_gitconfig_to_volume()` functions
- **Updated all Dockerfiles**: Changed user from `claude` to `ai-pod` in:
  - `ai-pod.Dockerfile` (main image)
  - `templates/Dockerfile` (template for custom agents)
  - Test fixtures in `tests/e2e.rs`
- **Updated documentation**: Changed references in `templates/skill.md` and `README.md` to reflect the new home directory path

## Implementation Details
- The `CONTAINER_HOME` constant is now used in all container path operations (volume mounts, file copies, directory creation)
- All function calls that previously passed `home_dir` as a parameter now use the constant directly
- The Dockerfile template still uses `{{AGENT}}` placeholder for the CMD instruction but hardcodes the user and home directory to `ai-pod`
- This change assumes all container images will have the `ai-pod` user with home directory `/home/ai-pod`, as enforced by the Dockerfile template

https://claude.ai/code/session_016gR1uvuveUHzvsQ1YGLtNJ