### PR TITLE
Add update command to fetch and run latest install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ ai-pod --workdir /path/to/project
 | `clean [--workdir PATH]` | Stop and remove the container for a workspace |
 | `run <command> [args...]` | Run a command in the container instead of the default |
 | `serve` | Start the shared server manually (normally auto-started) |
+| `update` | Fetch the latest install script and run it to upgrade |
 
 ### Run a specific command in the container
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,9 @@ pub enum Command {
         #[command(subcommand)]
         action: AllowedAction,
     },
+
+    /// Update ai-pod to the latest release
+    Update,
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Skip update check for internal/daemon commands
-    if !matches!(&cli.command, Some(Command::Serve)) {
+    if !matches!(&cli.command, Some(Command::Serve) | Some(Command::Update)) {
         let _ = tokio::time::timeout(
             std::time::Duration::from_secs(3),
             update::check_for_update(),
@@ -118,6 +118,10 @@ async fn main() -> Result<()> {
                 cli::Agent::Opencode => "opencode",
             };
             init_project(&workspace, agent_str)?;
+            return Ok(());
+        }
+        Some(Command::Update) => {
+            update::run_update().await?;
             return Ok(());
         }
         Some(Command::Allowed { action }) => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,7 +1,52 @@
+use anyhow::{Context, Result};
 use colored::Colorize;
+use std::io::Write;
+use std::process::{Command, Stdio};
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const RELEASES_URL: &str = "https://api.github.com/repos/mismosmi/ai-pod/releases/latest";
+const INSTALL_SCRIPT_URL: &str =
+    "https://raw.githubusercontent.com/mismosmi/ai-pod/main/install.sh";
+
+pub async fn run_update() -> Result<()> {
+    println!("{} {}", "Fetching".blue().bold(), INSTALL_SCRIPT_URL);
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .user_agent(format!("ai-pod/{CURRENT_VERSION}"))
+        .build()?;
+
+    let script = client
+        .get(INSTALL_SCRIPT_URL)
+        .send()
+        .await?
+        .error_for_status()
+        .context("Failed to download install script")?
+        .text()
+        .await?;
+
+    println!("{}", "Running install script...".blue().bold());
+
+    let mut child = Command::new("bash")
+        .stdin(Stdio::piped())
+        .spawn()
+        .context("Failed to spawn bash")?;
+
+    child
+        .stdin
+        .as_mut()
+        .context("Failed to open bash stdin")?
+        .write_all(script.as_bytes())
+        .context("Failed to write install script to bash")?;
+
+    let status = child.wait().context("Failed to wait for bash")?;
+
+    if !status.success() {
+        anyhow::bail!("Install script exited with {status}");
+    }
+
+    Ok(())
+}
 
 pub async fn check_for_update() {
     if let Ok(latest) = fetch_latest_version().await {


### PR DESCRIPTION
## Summary
This PR adds a new `update` command to ai-pod that allows users to upgrade to the latest release by fetching and executing the install script from the repository.

## Key Changes
- **New `run_update()` function** in `src/update.rs` that:
  - Fetches the install script from the main branch via GitHub raw content URL
  - Spawns a bash process and pipes the script to stdin
  - Handles errors gracefully with context-aware error messages
  - Uses a 30-second timeout for the HTTP request

- **CLI integration** in `src/cli.rs`:
  - Added new `Update` command variant to the `Command` enum
  - Added help text describing the update functionality

- **Main command handler** in `src/main.rs`:
  - Routes the `Update` command to the new `run_update()` function
  - Excludes the `Update` command from the background update check (similar to `Serve`)

- **Documentation** in `README.md`:
  - Added `update` command to the command reference table

## Implementation Details
- The update command uses `reqwest` to download the install script with a custom user agent
- The script is executed via bash stdin to avoid writing temporary files
- Proper error handling with `anyhow::Context` for debugging
- The update check is skipped when running the update command itself to avoid nested update checks

https://claude.ai/code/session_01R5jqc2yqHtDdzVJyqxsRKK