### PR TITLE
fix(tests): use opencode --version in e2e verify

### DIFF
--- a/tests/e2e_agents.sh
+++ b/tests/e2e_agents.sh
@@ -11,7 +11,7 @@ IMAGE="${2:?Usage: e2e_agents.sh <agent> <image>}"
 
 case "$AGENT" in
   claude)   VERIFY_ARGS="claude --version" ;;
-  opencode) VERIFY_ARGS="opencode version" ;;
+  opencode) VERIFY_ARGS="opencode --version" ;;
   *)        echo "Unknown agent: $AGENT"; exit 1 ;;
 esac
 


### PR DESCRIPTION
opencode's CLI has no `version` subcommand; it treats the token as a
positional project-path argument and fails with an lstat error. Use the
`--version` flag like the claude branch does.

https://claude.ai/code/session_01VSNFuaQV39UXVSkF5HXPWL