### PR TITLE
Fix shared server shutdown during image build

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -80,9 +80,10 @@ pub fn build_image(rt: &ContainerRuntime, dockerfile: &Path, image: &str, no_cac
         &dockerfile.parent().unwrap_or(Path::new(".")).to_string_lossy(),
     ]);
 
-    // Keep the shared server alive during the build: POST /keep-alive every 20 s.
-    // The server auto-shuts-down after 30 s of inactivity with no containers running,
-    // so without this the server would die mid-build.
+    // Keep the shared server alive during the build. The server auto-shuts-down
+    // after 30 s of inactivity with no containers running. POST /keep-alive
+    // immediately so the timer is bumped before the build's first long step,
+    // then re-bump every 10 s for safety margin.
     let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
     let keepalive_thread = std::thread::spawn(move || {
         let client = reqwest::blocking::Client::new();
@@ -90,8 +91,9 @@ pub fn build_image(rt: &ContainerRuntime, dockerfile: &Path, image: &str, no_cac
             "http://127.0.0.1:{}/keep-alive",
             crate::server::lifecycle::MCP_PORT
         );
+        let _ = client.post(&url).send();
         loop {
-            match stop_rx.recv_timeout(std::time::Duration::from_secs(20)) {
+            match stop_rx.recv_timeout(std::time::Duration::from_secs(10)) {
                 Ok(_) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                     let _ = client.post(&url).send();

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,11 @@ async fn launch_flow(cli: &Cli, rt: &ContainerRuntime) -> Result<()> {
     let image = image::image_name(&workspace);
     image::ensure_image(rt, &dockerfile, &image, cli.rebuild, cli.no_cache)?;
 
+    // Bridge the gap between build completion and the first authenticated
+    // request: re-arm the inactivity timer so the server doesn't shut down
+    // while we set up state and launch the container.
+    server::lifecycle::bump_keep_alive();
+
     // 6. Check server version compatibility
     server::lifecycle::check_server_version().await?;
 
@@ -320,6 +325,7 @@ async fn main() -> Result<()> {
             server::lifecycle::ensure_shared_server(&config)?;
             let image = image::image_name(&workspace);
             image::ensure_image(&rt, &dockerfile, &image, cli.rebuild, cli.no_cache)?;
+            server::lifecycle::bump_keep_alive();
             server::lifecycle::check_server_version().await?;
             let project_id = workspace::workspace_hash(&workspace);
             let state = server::lifecycle::get_or_create_project_state(&config, &workspace)?;

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -156,6 +156,18 @@ pub fn state_file_for(config: &AppConfig, workspace: &Path) -> PathBuf {
     config.project_state_file(&hash)
 }
 
+/// Best-effort blocking POST to `/keep-alive` to bump the shared server's
+/// inactivity timer. Errors are intentionally swallowed: the caller is
+/// re-arming the timer for the next operation, and any real connectivity
+/// problem will surface on the subsequent authenticated request.
+pub fn bump_keep_alive() {
+    let url = format!("http://127.0.0.1:{}/keep-alive", MCP_PORT);
+    let _ = reqwest::blocking::Client::new()
+        .post(&url)
+        .timeout(std::time::Duration::from_secs(2))
+        .send();
+}
+
 /// Ensure the shared server is running. Starts it if not alive.
 pub fn ensure_shared_server(config: &AppConfig) -> Result<()> {
     let state_path = config.server_state_file();
@@ -167,6 +179,9 @@ pub fn ensure_shared_server(config: &AppConfig) -> Result<()> {
     if let Some(pid) = state.pid
         && is_server_process_alive(pid, state.exe_path.as_deref())
     {
+        // Re-arm the inactivity timer so a freshly-arriving CLI command does
+        // not inherit a near-expired timer from the previous run.
+        bump_keep_alive();
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

Closes #55. Fixes three race conditions where the shared server's 30 s inactivity timer could expire while `ai-pod` was actively using it, causing the weekly e2e workflow to fail mid-build.

## Root cause

The existing keep-alive mechanism (added in #52) had three gaps:

1. **`build_image` waited 20 s before its first `POST /keep-alive`** (`src/image.rs:94`). Combined with the server's 30 s timeout, the margin was only 10 s — and the timer could already be near-expired when the build started.
2. **`ensure_shared_server` did not bump the timer when reusing an existing server** (`src/server/lifecycle.rs:170`). In `tests/e2e_agents.sh`, 9 combos run sequentially against a single server; each new combo inherited a near-expired timer from the previous one.
3. **The keep-alive thread terminated as soon as `build_image` returned**, but `check_server_version`, `reload_config`, and `launch_container` still had to run. Slow container start could outrun the remaining timer.

## Changes

- `src/image.rs` — POST `/keep-alive` immediately at build start; reduce interval from 20 s to 10 s.
- `src/server/lifecycle.rs` — add `bump_keep_alive()` helper; call it from `ensure_shared_server` on the reuse path.
- `src/main.rs` — call `bump_keep_alive()` after `ensure_image()` at both `Run` call sites, before `check_server_version`.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib` — 147/147 pass
- [ ] Re-run the weekly e2e workflow (`Weekly E2E Agent Tests`) and confirm all 9 combos pass
- [ ] Manually: `ai-pod serve &`, wait 25 s, then `ai-pod run` against a project with a missing image — confirm server stays up through the full build + container launch

https://claude.ai/code/session_01112kyAwPxtZYDP2aa8s4fc

---
_Generated by [Claude Code](https://claude.ai/code/session_01112kyAwPxtZYDP2aa8s4fc)_