### PR TITLE
feat: clarify sensitive-file prompt and add env-files subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,18 @@ pub enum Command {
         action: Option<AllowedAction>,
     },
 
+    /// Manage sensitive files in the workspace — hide them from the AI,
+    /// expose them, or silence startup warnings.
+    /// Run with no subcommand to open an interactive TUI.
+    EnvFiles {
+        #[command(subcommand)]
+        action: Option<EnvFilesAction>,
+
+        /// Workspace path (default: cwd)
+        #[arg(long)]
+        workdir: Option<PathBuf>,
+    },
+
     /// Shadow-mount a top-level workspace directory with an isolated per-workspace volume.
     /// The masked directory inside the container is backed by a named volume instead of
     /// the host's workspace, so container-only artifacts (e.g. node_modules) don't leak out.
@@ -151,6 +163,32 @@ pub enum CommandsAction {
         command_id: String,
         #[arg(long)]
         session: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum EnvFilesAction {
+    /// Print a list of all detected sensitive files with their status
+    List,
+    /// Move a workspace file into ~/.env-files/<slug>/ and replace with a symlink
+    Hide {
+        /// Path relative to the workspace
+        path: String,
+    },
+    /// Restore a hidden file back into the workspace
+    Unhide {
+        /// Path relative to the workspace
+        path: String,
+    },
+    /// Suppress future startup warnings for a workspace file (keeps it readable by the AI)
+    Ignore {
+        /// Path relative to the workspace
+        path: String,
+    },
+    /// Re-enable startup warnings for a previously ignored file
+    Unignore {
+        /// Path relative to the workspace
+        path: String,
     },
 }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored::Colorize;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
@@ -6,6 +6,26 @@ use walkdir::WalkDir;
 use crate::config::AppConfig;
 use crate::server::lifecycle::ProjectState;
 use crate::workspace::workspace_hash;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvFileStatus {
+    /// Symlink in workspace pointing into ~/.env-files/<slug>/ — AI cannot read.
+    Hidden,
+    /// Regular file in workspace, not in the ignore list — AI can read, warns at startup.
+    Exposed,
+    /// Regular file in workspace, in the ignore list — AI can read, no warning.
+    Ignored,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnvFileEntry {
+    pub rel_path: String,
+    pub abs_path: PathBuf,
+    pub status: EnvFileStatus,
+    /// For Hidden entries: where the real file lives.
+    /// For other entries: where it would be moved if hidden.
+    pub destination: PathBuf,
+}
 
 const CREDENTIAL_PATTERNS: &[&str] = &[
     ".env",
@@ -180,12 +200,17 @@ pub fn check_credentials(workspace: &Path, config: &AppConfig) -> Result<bool> {
 
     println!(
         "\n{}",
-        "⚠  Potential credential files found in workspace:"
+        "⚠  Potentially sensitive files detected in workspace:"
             .yellow()
             .bold()
     );
+    println!(
+        "  {}",
+        "The workspace is mounted into the AI container, so these files will be readable by the AI."
+            .dimmed()
+    );
 
-    let mut any_kept = false;
+    let mut any_exposed = false;
     let mut state_changed = false;
 
     for path in &pending {
@@ -193,35 +218,36 @@ pub fn check_credentials(workspace: &Path, config: &AppConfig) -> Result<bool> {
         println!("\n  {} {}", "•".yellow(), rel.display());
 
         let choices = &[
-            "Keep (allow in container, warn next time)",
-            "Ignore (never warn for this file again)",
-            "Move to ~/.env-files/<slug>/ and symlink",
+            "Hide from AI  (move to home directory, keep symlink for host tools)",
+            "Expose to AI  (keep in workspace, suppress future warnings)",
+            "Expose to AI  (keep in workspace, warn again next time)",
         ];
         let selection = dialoguer::Select::new()
-            .with_prompt("What would you like to do?")
+            .with_prompt("This file will be readable inside the container — what would you like to do?")
             .items(choices)
             .default(0)
             .interact()?;
 
         match selection {
             0 => {
-                any_kept = true;
-            }
-            1 => {
-                state.add_ignored_credential(&rel.to_string_lossy());
-                state_changed = true;
-            }
-            2 => {
                 let dst_dir = config.env_files_project_dir(workspace);
                 let file_name = path.file_name().unwrap_or_default();
                 let dst = dst_dir.join(file_name);
                 move_and_symlink(path, &dst)?;
                 println!(
-                    "  {} Moved to {} and symlinked",
+                    "  {} Hidden: moved to {} and replaced with a symlink",
                     "✓".green(),
                     dst.display()
                 );
                 state_changed = true;
+            }
+            1 => {
+                state.add_ignored_credential(&rel.to_string_lossy());
+                state_changed = true;
+                any_exposed = true;
+            }
+            2 => {
+                any_exposed = true;
             }
             _ => unreachable!(),
         }
@@ -231,7 +257,7 @@ pub fn check_credentials(workspace: &Path, config: &AppConfig) -> Result<bool> {
         state.save(&state_path)?;
     }
 
-    if any_kept {
+    if any_exposed {
         let proceed = dialoguer::Confirm::new()
             .with_prompt("Continue anyway?")
             .default(false)
@@ -252,6 +278,132 @@ fn move_and_symlink(src: &Path, dst: &Path) -> Result<()> {
         std::fs::remove_file(src)?;
     }
     std::os::unix::fs::symlink(dst, src)?;
+    Ok(())
+}
+
+/// Enumerate every sensitive file in the workspace, classified by management
+/// status. Symlinks pointing into `~/.env-files/<slug>/` are reported as
+/// `Hidden`; regular files are reported as `Exposed` or `Ignored` depending on
+/// the project state's ignore list. The result is sorted by relative path.
+pub fn list_env_files(workspace: &Path, config: &AppConfig) -> Vec<EnvFileEntry> {
+    let workspace_buf =
+        std::fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
+    let workspace = workspace_buf.as_path();
+    let env_dir = config.env_files_project_dir(workspace);
+    let hash = workspace_hash(workspace);
+    let state = ProjectState::load(&config.project_state_file(&hash));
+
+    let mut entries = Vec::new();
+
+    for ent in WalkDir::new(workspace)
+        .max_depth(5)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            let name = e.file_name().to_string_lossy();
+            !matches!(
+                name.as_ref(),
+                "node_modules" | ".git" | "target" | "__pycache__" | ".venv" | "venv"
+            )
+        })
+        .filter_map(|e| e.ok())
+    {
+        let path = ent.path();
+        if !is_credential_file(path) {
+            continue;
+        }
+        let ft = ent.file_type();
+        let rel = path
+            .strip_prefix(workspace)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string();
+        let file_name = path.file_name().unwrap_or_default();
+
+        if ft.is_symlink() {
+            let Ok(target) = std::fs::read_link(path) else {
+                continue;
+            };
+            let resolved = if target.is_absolute() {
+                target
+            } else {
+                path.parent().unwrap_or(workspace).join(&target)
+            };
+            if resolved.starts_with(&env_dir) {
+                entries.push(EnvFileEntry {
+                    rel_path: rel,
+                    abs_path: path.to_path_buf(),
+                    status: EnvFileStatus::Hidden,
+                    destination: resolved,
+                });
+            }
+        } else if ft.is_file() {
+            let status = if state.is_credential_ignored(&rel) {
+                EnvFileStatus::Ignored
+            } else {
+                EnvFileStatus::Exposed
+            };
+            entries.push(EnvFileEntry {
+                rel_path: rel,
+                abs_path: path.to_path_buf(),
+                status,
+                destination: env_dir.join(file_name),
+            });
+        }
+    }
+
+    entries.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+    entries
+}
+
+/// Move a workspace file into `~/.env-files/<slug>/` and replace it with a
+/// symlink pointing at the new location. Errors if the workspace path is
+/// already a symlink (i.e. the file is already hidden).
+pub fn hide_file(workspace: &Path, config: &AppConfig, rel_path: &str) -> Result<PathBuf> {
+    let src = workspace.join(rel_path);
+    let md = std::fs::symlink_metadata(&src)
+        .with_context(|| format!("File not found: {}", rel_path))?;
+    if md.file_type().is_symlink() {
+        anyhow::bail!("{} is already hidden", rel_path);
+    }
+    if !md.file_type().is_file() {
+        anyhow::bail!("{} is not a regular file", rel_path);
+    }
+    let dst_dir = config.env_files_project_dir(workspace);
+    let file_name = src.file_name().unwrap_or_default();
+    let dst = dst_dir.join(file_name);
+    move_and_symlink(&src, &dst)?;
+    Ok(dst)
+}
+
+/// Reverse of `hide_file`: resolve the symlink, move the real file back into
+/// the workspace, and remove the symlink. Errors if `rel_path` is not a
+/// symlink.
+pub fn unhide_file(workspace: &Path, rel_path: &str) -> Result<()> {
+    let src = workspace.join(rel_path);
+    let md = std::fs::symlink_metadata(&src)
+        .with_context(|| format!("File not found: {}", rel_path))?;
+    if !md.file_type().is_symlink() {
+        anyhow::bail!("{} is not hidden", rel_path);
+    }
+    let target = std::fs::read_link(&src)?;
+    let target = if target.is_absolute() {
+        target
+    } else {
+        src.parent().unwrap_or(workspace).join(target)
+    };
+    if !target.exists() {
+        anyhow::bail!(
+            "Symlink target is missing: {}. Refusing to remove the dangling symlink.",
+            target.display()
+        );
+    }
+    std::fs::remove_file(&src).context("Failed to remove workspace symlink")?;
+    if std::fs::rename(&target, &src).is_err() {
+        // Cross-device move fallback
+        std::fs::copy(&target, &src).context("Failed to copy file back into workspace")?;
+        std::fs::remove_file(&target).ok();
+    }
     Ok(())
 }
 
@@ -391,5 +543,126 @@ mod tests_scan {
         std::fs::write(sub.join("service-account.json"), r#"{}"#).unwrap();
         let found = scan_workspace(dir.path());
         assert_eq!(found.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod tests_env_files_management {
+    use super::*;
+    use crate::server::lifecycle::ProjectState;
+    use tempfile::TempDir;
+
+    fn temp_config(home: &Path) -> AppConfig {
+        let config_dir = home.join(".ai-pod");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        AppConfig {
+            runtime_settings: config_dir.join("runtime-settings.json"),
+            config_dir,
+            home_dir: home.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn remove_ignored_credential_removes_entry() {
+        let mut state = ProjectState::default();
+        state.add_ignored_credential(".env");
+        state.add_ignored_credential("id_rsa");
+        assert!(state.is_credential_ignored(".env"));
+        state.remove_ignored_credential(".env");
+        assert!(!state.is_credential_ignored(".env"));
+        assert!(state.is_credential_ignored("id_rsa"));
+    }
+
+    #[test]
+    fn hide_file_moves_and_symlinks() {
+        let home = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        let config = temp_config(home.path());
+
+        let src = workspace.path().join(".env");
+        std::fs::write(&src, "SECRET=123").unwrap();
+
+        let dst = hide_file(workspace.path(), &config, ".env").unwrap();
+
+        assert!(dst.exists(), "destination file should exist");
+        assert_eq!(std::fs::read_to_string(&dst).unwrap(), "SECRET=123");
+
+        let md = std::fs::symlink_metadata(&src).unwrap();
+        assert!(md.file_type().is_symlink(), "workspace entry should be a symlink");
+        assert_eq!(std::fs::read_link(&src).unwrap(), dst);
+    }
+
+    #[test]
+    fn hide_file_refuses_already_hidden_file() {
+        let home = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        let config = temp_config(home.path());
+
+        let src = workspace.path().join(".env");
+        std::fs::write(&src, "SECRET=123").unwrap();
+        hide_file(workspace.path(), &config, ".env").unwrap();
+
+        let err = hide_file(workspace.path(), &config, ".env").unwrap_err();
+        assert!(err.to_string().contains("already hidden"));
+    }
+
+    #[test]
+    fn unhide_file_restores_real_file() {
+        let home = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        let config = temp_config(home.path());
+
+        let src = workspace.path().join(".env");
+        std::fs::write(&src, "SECRET=123").unwrap();
+        hide_file(workspace.path(), &config, ".env").unwrap();
+
+        unhide_file(workspace.path(), ".env").unwrap();
+
+        let md = std::fs::symlink_metadata(&src).unwrap();
+        assert!(md.file_type().is_file(), "workspace entry should be a regular file again");
+        assert_eq!(std::fs::read_to_string(&src).unwrap(), "SECRET=123");
+        let hidden = config.env_files_project_dir(workspace.path()).join(".env");
+        assert!(!hidden.exists(), "hidden file should be removed from env-files dir");
+    }
+
+    #[test]
+    fn unhide_file_refuses_regular_file() {
+        let workspace = TempDir::new().unwrap();
+        std::fs::write(workspace.path().join(".env"), "SECRET=123").unwrap();
+        let err = unhide_file(workspace.path(), ".env").unwrap_err();
+        assert!(err.to_string().contains("not hidden"));
+    }
+
+    #[test]
+    fn list_env_files_classifies_all_three_states() {
+        let home = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        let config = temp_config(home.path());
+
+        // Exposed file
+        std::fs::write(workspace.path().join(".env"), "A=1").unwrap();
+        // Ignored file
+        std::fs::write(workspace.path().join("id_rsa"), "key").unwrap();
+        // Hidden file
+        std::fs::write(workspace.path().join(".env.local"), "B=2").unwrap();
+        hide_file(workspace.path(), &config, ".env.local").unwrap();
+
+        // Mark id_rsa as ignored
+        let hash = workspace_hash(workspace.path());
+        let state_path = config.project_state_file(&hash);
+        let mut state = ProjectState::load(&state_path);
+        state.add_ignored_credential("id_rsa");
+        state.save(&state_path).unwrap();
+
+        let entries = list_env_files(workspace.path(), &config);
+        assert_eq!(entries.len(), 3);
+
+        let by_path: std::collections::HashMap<_, _> = entries
+            .iter()
+            .map(|e| (e.rel_path.clone(), e.status))
+            .collect();
+        assert_eq!(by_path[".env"], EnvFileStatus::Exposed);
+        assert_eq!(by_path["id_rsa"], EnvFileStatus::Ignored);
+        assert_eq!(by_path[".env.local"], EnvFileStatus::Hidden);
     }
 }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -231,8 +231,7 @@ pub fn check_credentials(workspace: &Path, config: &AppConfig) -> Result<bool> {
         match selection {
             0 => {
                 let dst_dir = config.env_files_project_dir(workspace);
-                let file_name = path.file_name().unwrap_or_default();
-                let dst = dst_dir.join(file_name);
+                let dst = dst_dir.join(rel);
                 move_and_symlink(path, &dst)?;
                 println!(
                     "  {} Hidden: moved to {} and replaced with a symlink",
@@ -318,7 +317,6 @@ pub fn list_env_files(workspace: &Path, config: &AppConfig) -> Vec<EnvFileEntry>
             .unwrap_or(path)
             .to_string_lossy()
             .to_string();
-        let file_name = path.file_name().unwrap_or_default();
 
         if ft.is_symlink() {
             let Ok(target) = std::fs::read_link(path) else {
@@ -343,11 +341,12 @@ pub fn list_env_files(workspace: &Path, config: &AppConfig) -> Vec<EnvFileEntry>
             } else {
                 EnvFileStatus::Exposed
             };
+            let destination = env_dir.join(&rel);
             entries.push(EnvFileEntry {
                 rel_path: rel,
                 abs_path: path.to_path_buf(),
                 status,
-                destination: env_dir.join(file_name),
+                destination,
             });
         }
     }
@@ -356,10 +355,30 @@ pub fn list_env_files(workspace: &Path, config: &AppConfig) -> Vec<EnvFileEntry>
     entries
 }
 
+/// Verify a workspace-relative path is safe to join onto `~/.env-files/<slug>/`
+/// — it must not be absolute and must not contain any `..` components.
+fn validate_rel_path(rel_path: &str) -> Result<()> {
+    let p = Path::new(rel_path);
+    for c in p.components() {
+        match c {
+            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+            _ => anyhow::bail!(
+                "Invalid relative path (must not contain '..' or be absolute): {}",
+                rel_path
+            ),
+        }
+    }
+    Ok(())
+}
+
 /// Move a workspace file into `~/.env-files/<slug>/` and replace it with a
-/// symlink pointing at the new location. Errors if the workspace path is
-/// already a symlink (i.e. the file is already hidden).
+/// symlink pointing at the new location. The file's path relative to the
+/// workspace root is preserved under the env-files dir, so nested files like
+/// `packages/a/.env` and `packages/b/.env` don't collide.
+/// Errors if the workspace path is already a symlink (i.e. the file is already
+/// hidden).
 pub fn hide_file(workspace: &Path, config: &AppConfig, rel_path: &str) -> Result<PathBuf> {
+    validate_rel_path(rel_path)?;
     let src = workspace.join(rel_path);
     let md = std::fs::symlink_metadata(&src)
         .with_context(|| format!("File not found: {}", rel_path))?;
@@ -370,8 +389,7 @@ pub fn hide_file(workspace: &Path, config: &AppConfig, rel_path: &str) -> Result
         anyhow::bail!("{} is not a regular file", rel_path);
     }
     let dst_dir = config.env_files_project_dir(workspace);
-    let file_name = src.file_name().unwrap_or_default();
-    let dst = dst_dir.join(file_name);
+    let dst = dst_dir.join(rel_path);
     move_and_symlink(&src, &dst)?;
     Ok(dst)
 }
@@ -380,6 +398,7 @@ pub fn hide_file(workspace: &Path, config: &AppConfig, rel_path: &str) -> Result
 /// the workspace, and remove the symlink. Errors if `rel_path` is not a
 /// symlink.
 pub fn unhide_file(workspace: &Path, rel_path: &str) -> Result<()> {
+    validate_rel_path(rel_path)?;
     let src = workspace.join(rel_path);
     let md = std::fs::symlink_metadata(&src)
         .with_context(|| format!("File not found: {}", rel_path))?;
@@ -403,6 +422,14 @@ pub fn unhide_file(workspace: &Path, rel_path: &str) -> Result<()> {
         // Cross-device move fallback
         std::fs::copy(&target, &src).context("Failed to copy file back into workspace")?;
         std::fs::remove_file(&target).ok();
+    }
+    // Best-effort cleanup of now-empty parent dirs inside the env-files dir.
+    let mut parent = target.parent();
+    while let Some(p) = parent {
+        if std::fs::remove_dir(p).is_err() {
+            break;
+        }
+        parent = p.parent();
     }
     Ok(())
 }
@@ -664,5 +691,48 @@ mod tests_env_files_management {
         assert_eq!(by_path[".env"], EnvFileStatus::Exposed);
         assert_eq!(by_path["id_rsa"], EnvFileStatus::Ignored);
         assert_eq!(by_path[".env.local"], EnvFileStatus::Hidden);
+    }
+
+    #[test]
+    fn hide_file_preserves_nested_path() {
+        // Regression: two files with the same basename in different
+        // subdirectories must NOT collide in ~/.env-files/<slug>/.
+        let home = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        let config = temp_config(home.path());
+
+        let a_dir = workspace.path().join("packages").join("a");
+        let b_dir = workspace.path().join("packages").join("b");
+        std::fs::create_dir_all(&a_dir).unwrap();
+        std::fs::create_dir_all(&b_dir).unwrap();
+        std::fs::write(a_dir.join(".env"), "A=1").unwrap();
+        std::fs::write(b_dir.join(".env"), "B=2").unwrap();
+
+        let dst_a = hide_file(workspace.path(), &config, "packages/a/.env").unwrap();
+        let dst_b = hide_file(workspace.path(), &config, "packages/b/.env").unwrap();
+
+        assert_ne!(dst_a, dst_b, "destinations must not collide");
+        assert_eq!(std::fs::read_to_string(&dst_a).unwrap(), "A=1");
+        assert_eq!(std::fs::read_to_string(&dst_b).unwrap(), "B=2");
+
+        // Symlinks in the workspace should still resolve to the right targets.
+        assert_eq!(std::fs::read_link(a_dir.join(".env")).unwrap(), dst_a);
+        assert_eq!(std::fs::read_link(b_dir.join(".env")).unwrap(), dst_b);
+
+        // And unhide should put each back correctly.
+        unhide_file(workspace.path(), "packages/a/.env").unwrap();
+        unhide_file(workspace.path(), "packages/b/.env").unwrap();
+        assert_eq!(std::fs::read_to_string(a_dir.join(".env")).unwrap(), "A=1");
+        assert_eq!(std::fs::read_to_string(b_dir.join(".env")).unwrap(), "B=2");
+    }
+
+    #[test]
+    fn hide_file_rejects_path_traversal() {
+        let home = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        let config = temp_config(home.path());
+        std::fs::write(workspace.path().join(".env"), "X=1").unwrap();
+        let err = hide_file(workspace.path(), &config, "../escape/.env").unwrap_err();
+        assert!(err.to_string().contains("Invalid"), "got: {}", err);
     }
 }

--- a/src/env_files_cli.rs
+++ b/src/env_files_cli.rs
@@ -1,0 +1,364 @@
+//! Host-side `ai-pod env-files` subcommand: list, hide, unhide, ignore,
+//! unignore, plus a ratatui TUI for interactive management of sensitive files
+//! in a workspace.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::path::Path;
+use std::time::Duration;
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+
+use crate::config::AppConfig;
+use crate::credentials::{EnvFileEntry, EnvFileStatus, hide_file, list_env_files, unhide_file};
+use crate::server::lifecycle::ProjectState;
+use crate::workspace::workspace_hash;
+
+pub fn run_list(config: &AppConfig, workspace: &Path) -> Result<()> {
+    let entries = list_env_files(workspace, config);
+    if entries.is_empty() {
+        println!("{}", "No sensitive files detected.".dimmed());
+        return Ok(());
+    }
+    for e in entries {
+        let tag = status_tag(e.status);
+        println!("{}  {}", tag, e.rel_path);
+    }
+    Ok(())
+}
+
+pub fn run_hide(config: &AppConfig, workspace: &Path, rel: &str) -> Result<()> {
+    let dst = hide_file(workspace, config, rel)?;
+    println!(
+        "{} {} → {}",
+        "Hidden:".green().bold(),
+        rel,
+        dst.display()
+    );
+    Ok(())
+}
+
+pub fn run_unhide(workspace: &Path, rel: &str) -> Result<()> {
+    unhide_file(workspace, rel)?;
+    println!("{} {}", "Unhidden:".green().bold(), rel);
+    Ok(())
+}
+
+pub fn run_ignore(config: &AppConfig, workspace: &Path, rel: &str) -> Result<()> {
+    let hash = workspace_hash(workspace);
+    let state_path = config.project_state_file(&hash);
+    let mut state = ProjectState::load(&state_path);
+    if state.is_credential_ignored(rel) {
+        println!("{} {}", "Already ignored:".yellow(), rel);
+        return Ok(());
+    }
+    state.add_ignored_credential(rel);
+    state.save(&state_path)?;
+    println!("{} {}", "Ignored:".green().bold(), rel);
+    Ok(())
+}
+
+pub fn run_unignore(config: &AppConfig, workspace: &Path, rel: &str) -> Result<()> {
+    let hash = workspace_hash(workspace);
+    let state_path = config.project_state_file(&hash);
+    let mut state = ProjectState::load(&state_path);
+    if !state.is_credential_ignored(rel) {
+        println!("{} {}", "Not ignored:".yellow(), rel);
+        return Ok(());
+    }
+    state.remove_ignored_credential(rel);
+    state.save(&state_path)?;
+    println!("{} {}", "Unignored:".green().bold(), rel);
+    Ok(())
+}
+
+fn status_tag(status: EnvFileStatus) -> String {
+    match status {
+        EnvFileStatus::Hidden => "[hidden] ".to_string(),
+        EnvFileStatus::Exposed => "[exposed]".to_string(),
+        EnvFileStatus::Ignored => "[ignored]".to_string(),
+    }
+}
+
+// ---------------- TUI ----------------
+
+pub fn run_tui(config: &AppConfig, workspace: &Path) -> Result<()> {
+    enable_raw_mode().context("enable raw mode")?;
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen).context("enter alt screen")?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("create terminal")?;
+
+    let result = tui_loop(&mut terminal, config, workspace);
+
+    disable_raw_mode().ok();
+    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+    terminal.show_cursor().ok();
+
+    result
+}
+
+fn tui_loop(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    config: &AppConfig,
+    workspace: &Path,
+) -> Result<()> {
+    let mut entries = list_env_files(workspace, config);
+    let mut list_state = ListState::default();
+    if !entries.is_empty() {
+        list_state.select(Some(0));
+    }
+    let mut message: Option<(String, Color)> = None;
+
+    loop {
+        terminal.draw(|f| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(3), Constraint::Length(3)])
+                .split(f.area());
+
+            let items: Vec<ListItem> = entries
+                .iter()
+                .map(|e| {
+                    let (tag, color) = match e.status {
+                        EnvFileStatus::Hidden => ("[hidden] ", Color::Green),
+                        EnvFileStatus::Exposed => ("[exposed]", Color::Red),
+                        EnvFileStatus::Ignored => ("[ignored]", Color::Yellow),
+                    };
+                    ListItem::new(Line::from(vec![
+                        Span::styled(tag, Style::default().fg(color)),
+                        Span::raw("  "),
+                        Span::raw(e.rel_path.clone()),
+                    ]))
+                })
+                .collect();
+
+            let title =
+                "sensitive files  (↑/↓ select · h hide · u unhide · i ignore · r unignore · q quit)";
+            let list = List::new(items)
+                .block(Block::default().borders(Borders::ALL).title(title))
+                .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+            f.render_stateful_widget(list, chunks[0], &mut list_state);
+
+            let footer_text = if let Some((msg, color)) = &message {
+                Line::from(Span::styled(msg.clone(), Style::default().fg(*color)))
+            } else {
+                match list_state.selected().and_then(|i| entries.get(i)) {
+                    Some(e) => {
+                        let label = match e.status {
+                            EnvFileStatus::Hidden => "Stored at",
+                            EnvFileStatus::Exposed | EnvFileStatus::Ignored => "Would hide to",
+                        };
+                        Line::from(vec![
+                            Span::styled(
+                                format!("{}: ", label),
+                                Style::default().add_modifier(Modifier::BOLD),
+                            ),
+                            Span::raw(e.destination.display().to_string()),
+                        ])
+                    }
+                    None => Line::from(Span::styled(
+                        "No sensitive files detected in this workspace.",
+                        Style::default().fg(Color::DarkGray),
+                    )),
+                }
+            };
+            let footer = Paragraph::new(footer_text)
+                .block(Block::default().borders(Borders::ALL).title("details"));
+            f.render_widget(footer, chunks[1]);
+        })?;
+
+        if event::poll(Duration::from_millis(250))? {
+            if let Event::Key(KeyEvent { code, kind, .. }) = event::read()? {
+                if kind != KeyEventKind::Press {
+                    continue;
+                }
+                message = None;
+                match code {
+                    KeyCode::Char('q') | KeyCode::Esc => break,
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if !entries.is_empty() {
+                            let cur = list_state.selected().unwrap_or(0);
+                            let next = (cur + 1).min(entries.len() - 1);
+                            list_state.select(Some(next));
+                        }
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        let cur = list_state.selected().unwrap_or(0);
+                        list_state.select(Some(cur.saturating_sub(1)));
+                    }
+                    KeyCode::Char('h') => {
+                        if let Some(entry) = selected_entry(&entries, &list_state).cloned() {
+                            message = Some(apply_action(
+                                config,
+                                workspace,
+                                &entry,
+                                EnvFileAction::Hide,
+                            ));
+                            entries = list_env_files(workspace, config);
+                            reselect(&entries, &mut list_state, &entry.rel_path);
+                        }
+                    }
+                    KeyCode::Char('u') => {
+                        if let Some(entry) = selected_entry(&entries, &list_state).cloned() {
+                            message = Some(apply_action(
+                                config,
+                                workspace,
+                                &entry,
+                                EnvFileAction::Unhide,
+                            ));
+                            entries = list_env_files(workspace, config);
+                            reselect(&entries, &mut list_state, &entry.rel_path);
+                        }
+                    }
+                    KeyCode::Char('i') => {
+                        if let Some(entry) = selected_entry(&entries, &list_state).cloned() {
+                            message = Some(apply_action(
+                                config,
+                                workspace,
+                                &entry,
+                                EnvFileAction::Ignore,
+                            ));
+                            entries = list_env_files(workspace, config);
+                            reselect(&entries, &mut list_state, &entry.rel_path);
+                        }
+                    }
+                    KeyCode::Char('r') => {
+                        if let Some(entry) = selected_entry(&entries, &list_state).cloned() {
+                            message = Some(apply_action(
+                                config,
+                                workspace,
+                                &entry,
+                                EnvFileAction::Unignore,
+                            ));
+                            entries = list_env_files(workspace, config);
+                            reselect(&entries, &mut list_state, &entry.rel_path);
+                        }
+                    }
+                    KeyCode::Char('R') => {
+                        entries = list_env_files(workspace, config);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Copy, Clone)]
+enum EnvFileAction {
+    Hide,
+    Unhide,
+    Ignore,
+    Unignore,
+}
+
+fn apply_action(
+    config: &AppConfig,
+    workspace: &Path,
+    entry: &EnvFileEntry,
+    action: EnvFileAction,
+) -> (String, Color) {
+    let run = || -> Result<Option<String>> {
+        match action {
+            EnvFileAction::Hide => {
+                if entry.status == EnvFileStatus::Hidden {
+                    return Ok(None);
+                }
+                let hash = workspace_hash(workspace);
+                let state_path = config.project_state_file(&hash);
+                let mut state = ProjectState::load(&state_path);
+                if state.is_credential_ignored(&entry.rel_path) {
+                    state.remove_ignored_credential(&entry.rel_path);
+                    state.save(&state_path)?;
+                }
+                let dst = hide_file(workspace, config, &entry.rel_path)?;
+                Ok(Some(format!("Hidden: {} → {}", entry.rel_path, dst.display())))
+            }
+            EnvFileAction::Unhide => {
+                if entry.status != EnvFileStatus::Hidden {
+                    return Ok(None);
+                }
+                unhide_file(workspace, &entry.rel_path)?;
+                Ok(Some(format!("Unhidden: {}", entry.rel_path)))
+            }
+            EnvFileAction::Ignore => {
+                if entry.status != EnvFileStatus::Exposed {
+                    return Ok(None);
+                }
+                let hash = workspace_hash(workspace);
+                let state_path = config.project_state_file(&hash);
+                let mut state = ProjectState::load(&state_path);
+                state.add_ignored_credential(&entry.rel_path);
+                state.save(&state_path)?;
+                Ok(Some(format!("Ignored: {}", entry.rel_path)))
+            }
+            EnvFileAction::Unignore => {
+                if entry.status != EnvFileStatus::Ignored {
+                    return Ok(None);
+                }
+                let hash = workspace_hash(workspace);
+                let state_path = config.project_state_file(&hash);
+                let mut state = ProjectState::load(&state_path);
+                state.remove_ignored_credential(&entry.rel_path);
+                state.save(&state_path)?;
+                Ok(Some(format!("Unignored: {}", entry.rel_path)))
+            }
+        }
+    };
+    match run() {
+        Ok(Some(msg)) => (msg, Color::Green),
+        Ok(None) => (
+            format!(
+                "{} — no action: {}",
+                entry.rel_path,
+                action_not_applicable_reason(action, entry.status)
+            ),
+            Color::Yellow,
+        ),
+        Err(e) => (e.to_string(), Color::Red),
+    }
+}
+
+fn action_not_applicable_reason(action: EnvFileAction, status: EnvFileStatus) -> &'static str {
+    match (action, status) {
+        (EnvFileAction::Hide, EnvFileStatus::Hidden) => "already hidden",
+        (EnvFileAction::Unhide, _) => "not hidden",
+        (EnvFileAction::Ignore, EnvFileStatus::Hidden) => "hidden files don't need ignoring",
+        (EnvFileAction::Ignore, EnvFileStatus::Ignored) => "already ignored",
+        (EnvFileAction::Unignore, _) => "not ignored",
+        _ => "no change required",
+    }
+}
+
+fn selected_entry<'a>(
+    entries: &'a [EnvFileEntry],
+    list_state: &ListState,
+) -> Option<&'a EnvFileEntry> {
+    list_state.selected().and_then(|i| entries.get(i))
+}
+
+fn reselect(entries: &[EnvFileEntry], list_state: &mut ListState, target_rel: &str) {
+    if entries.is_empty() {
+        list_state.select(None);
+        return;
+    }
+    let idx = entries
+        .iter()
+        .position(|e| e.rel_path == target_rel)
+        .unwrap_or_else(|| list_state.selected().unwrap_or(0).min(entries.len() - 1));
+    list_state.select(Some(idx));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod commands_cli;
 pub mod config;
 pub mod container;
 pub mod credentials;
+pub mod env_files_cli;
 pub mod image;
 pub mod runtime;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use ai_pod::{
-    cli, commands_cli, config, container, credentials, image, runtime, server, update, workspace,
+    cli, commands_cli, config, container, credentials, env_files_cli, image, runtime, server,
+    update, workspace,
 };
 
 use anyhow::{Context, Result};
@@ -7,7 +8,7 @@ use clap::Parser;
 use colored::Colorize;
 use std::path::Path;
 
-use cli::{AllowedAction, Cli, Command, CommandsAction};
+use cli::{AllowedAction, Cli, Command, CommandsAction, EnvFilesAction};
 use config::AppConfig;
 use runtime::ContainerRuntime;
 
@@ -310,6 +311,29 @@ async fn main() -> Result<()> {
         }
         Some(Command::Update) => {
             update::run_update().await?;
+            return Ok(());
+        }
+        Some(Command::EnvFiles { action, workdir }) => {
+            let config = AppConfig::new()?;
+            config.init()?;
+            let ws = workdir.clone().or_else(|| cli.workdir.clone());
+            let workspace = resolve_workspace(&ws)?;
+            match action {
+                None => env_files_cli::run_tui(&config, &workspace)?,
+                Some(EnvFilesAction::List) => env_files_cli::run_list(&config, &workspace)?,
+                Some(EnvFilesAction::Hide { path }) => {
+                    env_files_cli::run_hide(&config, &workspace, path)?
+                }
+                Some(EnvFilesAction::Unhide { path }) => {
+                    env_files_cli::run_unhide(&workspace, path)?
+                }
+                Some(EnvFilesAction::Ignore { path }) => {
+                    env_files_cli::run_ignore(&config, &workspace, path)?
+                }
+                Some(EnvFilesAction::Unignore { path }) => {
+                    env_files_cli::run_unignore(&config, &workspace, path)?
+                }
+            }
             return Ok(());
         }
         Some(Command::Allowed { action }) => {

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -90,6 +90,10 @@ impl ProjectState {
         }
     }
 
+    pub fn remove_ignored_credential(&mut self, rel_path: &str) {
+        self.ignored_credential_files.retain(|p| p != rel_path);
+    }
+
     pub fn is_masked(&self, dir: &str) -> bool {
         self.masked_directories.iter().any(|d| d == dir)
     }


### PR DESCRIPTION
Closes #88.

## Summary

- Reworded the startup sensitive-file prompt. "Hide from AI" is now the default first choice; the two "keep in workspace" choices are both labelled **"Expose to AI"** so it's clear that the previous `Ignore` option *doesn't* hide the file — it just silences the warning while the file stays readable by the container.
- New `ai-pod env-files` subcommand with an interactive ratatui TUI (`h` hide, `u` unhide, `i` ignore, `r` unignore) and matching non-interactive subcommands (`list`, `hide`, `unhide`, `ignore`, `unignore`). Each entry is classified as `[hidden]` / `[exposed]` / `[ignored]` based on whether its workspace entry is a symlink into `~/.env-files/<slug>/` and whether it's in the project's ignore list.
- Added `ProjectState::remove_ignored_credential` and a public `unhide_file` helper that reverses `move_and_symlink`.

## New wording

Before:
```
⚠  Potential credential files found in workspace:
  • .env
  What would you like to do?
  > Keep (allow in container, warn next time)
    Ignore (never warn for this file again)
    Move to ~/.env-files/<slug>/ and symlink
```

After:
```
⚠  Potentially sensitive files detected in workspace:
  The workspace is mounted into the AI container, so these files will be readable by the AI.
  • .env
  This file will be readable inside the container — what would you like to do?
  > Hide from AI  (move to home directory, keep symlink for host tools)
    Expose to AI  (keep in workspace, suppress future warnings)
    Expose to AI  (keep in workspace, warn again next time)
```

## Test plan
- [x] `cargo test --lib` (111 tests, 7 new — `hide_file_moves_and_symlinks`, `hide_file_refuses_already_hidden_file`, `unhide_file_restores_real_file`, `unhide_file_refuses_regular_file`, `list_env_files_classifies_all_three_states`, `remove_ignored_credential_removes_entry`)
- [x] `cargo test` end-to-end (12 e2e + rate_limit) still green
- [x] Manual: `ai-pod env-files --workdir <ws> hide .env` → workspace entry becomes a symlink into `~/.env-files/<slug>/`; `unhide .env` puts the real file back; `ignore`/`unignore` toggle the state file; `list` reports the correct status for all three states.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MtdaVvtzAE5sHTYKJf9DxA)_