### PR TITLE
feat: add `ai-pod mount` for global host bind-mounts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,6 +211,10 @@ pub enum MountAction {
         /// Mount as read-write (default: read-only)
         #[arg(long)]
         writable: bool,
+        /// Skip the interactive confirmation when the path matches a built-in
+        /// warn-list (credentials, system paths, ai-pod's own state, etc.).
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
     /// Remove a mount by host path (use the exact host path from `mount list`).
     Remove {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,6 +134,12 @@ pub enum Command {
         workdir: Option<PathBuf>,
     },
 
+    /// Manage host-path bind mounts applied to every ai-pod container.
+    Mount {
+        #[command(subcommand)]
+        action: MountAction,
+    },
+
     /// Update ai-pod to the latest release
     Update,
 }
@@ -189,6 +195,27 @@ pub enum EnvFilesAction {
     Unignore {
         /// Path relative to the workspace
         path: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum MountAction {
+    /// List configured global mounts
+    List,
+    /// Add a host path to the global mount list.
+    /// Spec is `host[:container]`; if container is omitted, the host
+    /// path must be under $HOME and is mirrored under /home/ai-pod.
+    Add {
+        /// `host[:container]` — e.g. `~/.claude/skills` or `/etc/foo:/run/foo`
+        spec: String,
+        /// Mount as read-write (default: read-only)
+        #[arg(long)]
+        writable: bool,
+    },
+    /// Remove a mount by host path (use the exact host path from `mount list`).
+    Remove {
+        /// Host path of the mount to remove
+        host: String,
     },
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,102 @@
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 pub struct AppConfig {
     pub config_dir: PathBuf,
     pub runtime_settings: PathBuf,
     pub home_dir: PathBuf,
+}
+
+/// A user-configured host-to-container bind mount applied to every ai-pod
+/// container launch. Stored as part of [`GlobalConfig`] in
+/// `~/.ai-pod/config.json`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct MountSpec {
+    /// Tilde-expanded absolute host path, as the user supplied it. Symlinks
+    /// are intentionally NOT resolved so users can mount things like a
+    /// `~/.claude/skills` directory that is itself a symlink.
+    pub host: String,
+    /// Explicit container target path, or `None` to mirror under
+    /// `/home/ai-pod`. When `None`, the host path must be under the user's
+    /// `$HOME` directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container: Option<String>,
+    /// Read-only by default. Set true via `--writable` on `mount add`.
+    #[serde(default)]
+    pub writable: bool,
+}
+
+/// Global ai-pod configuration shared across all workspaces. Persists to
+/// `~/.ai-pod/config.json` with 0o600 permissions.
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct GlobalConfig {
+    #[serde(default)]
+    pub mounts: Vec<MountSpec>,
+}
+
+impl GlobalConfig {
+    pub fn path(config: &AppConfig) -> PathBuf {
+        config.config_dir.join("config.json")
+    }
+
+    /// Load `~/.ai-pod/config.json`. Returns default if missing or malformed
+    /// (with a stderr warning in the malformed case) so a corrupt file never
+    /// blocks a launch.
+    pub fn load(config: &AppConfig) -> Self {
+        let path = Self::path(config);
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => return Self::default(),
+        };
+        match serde_json::from_str(&raw) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "warning: ignoring malformed {}: {}",
+                    path.display(),
+                    e
+                );
+                Self::default()
+            }
+        }
+    }
+
+    pub fn save(&self, config: &AppConfig) -> Result<()> {
+        let path = Self::path(config);
+        let json = serde_json::to_string_pretty(self)?;
+        let tmp = path.with_extension("tmp");
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)
+            .context("Failed to write global config")?;
+        file.write_all(json.as_bytes())
+            .context("Failed to write global config contents")?;
+        std::fs::rename(&tmp, &path).context("Failed to rename global config")?;
+        Ok(())
+    }
+
+    /// Returns false if a mount with the same host path already exists.
+    pub fn add(&mut self, spec: MountSpec) -> bool {
+        if self.mounts.iter().any(|m| m.host == spec.host) {
+            return false;
+        }
+        self.mounts.push(spec);
+        true
+    }
+
+    /// Returns true if a matching mount was removed.
+    pub fn remove(&mut self, host: &str) -> bool {
+        let before = self.mounts.len();
+        self.mounts.retain(|m| m.host != host);
+        before != self.mounts.len()
+    }
 }
 
 impl AppConfig {
@@ -138,5 +230,90 @@ mod tests {
         assert!(!config.config_dir.exists());
         config.init().unwrap();
         assert!(config.config_dir.exists());
+    }
+
+    #[test]
+    fn global_config_load_missing_returns_default() {
+        let dir = TempDir::new().unwrap();
+        let config = temp_config(&dir);
+        let loaded = GlobalConfig::load(&config);
+        assert!(loaded.mounts.is_empty());
+    }
+
+    #[test]
+    fn global_config_round_trips() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let config = temp_config(&dir);
+        config.init().unwrap();
+
+        let mut gc = GlobalConfig::default();
+        assert!(gc.add(MountSpec {
+            host: "/home/user/.claude/skills".into(),
+            container: None,
+            writable: false,
+        }));
+        assert!(gc.add(MountSpec {
+            host: "/etc/secret.pem".into(),
+            container: Some("/run/secrets/secret.pem".into()),
+            writable: true,
+        }));
+        gc.save(&config).unwrap();
+
+        let path = GlobalConfig::path(&config);
+        let perms = std::fs::metadata(&path).unwrap().permissions();
+        assert_eq!(
+            perms.mode() & 0o777,
+            0o600,
+            "config.json must be 0o600 — may contain references to secret paths"
+        );
+
+        let loaded = GlobalConfig::load(&config);
+        assert_eq!(loaded.mounts.len(), 2);
+        assert_eq!(loaded.mounts[0].host, "/home/user/.claude/skills");
+        assert_eq!(loaded.mounts[0].container, None);
+        assert!(!loaded.mounts[0].writable);
+        assert_eq!(loaded.mounts[1].host, "/etc/secret.pem");
+        assert_eq!(
+            loaded.mounts[1].container.as_deref(),
+            Some("/run/secrets/secret.pem")
+        );
+        assert!(loaded.mounts[1].writable);
+    }
+
+    #[test]
+    fn global_config_add_rejects_duplicate_host() {
+        let mut gc = GlobalConfig::default();
+        let spec = MountSpec {
+            host: "/foo".into(),
+            container: None,
+            writable: false,
+        };
+        assert!(gc.add(spec.clone()));
+        assert!(!gc.add(spec));
+        assert_eq!(gc.mounts.len(), 1);
+    }
+
+    #[test]
+    fn global_config_remove_reports_match() {
+        let mut gc = GlobalConfig::default();
+        gc.add(MountSpec {
+            host: "/foo".into(),
+            container: None,
+            writable: false,
+        });
+        assert!(gc.remove("/foo"));
+        assert!(!gc.remove("/foo"));
+        assert!(gc.mounts.is_empty());
+    }
+
+    #[test]
+    fn global_config_load_malformed_returns_default() {
+        let dir = TempDir::new().unwrap();
+        let config = temp_config(&dir);
+        config.init().unwrap();
+        std::fs::write(GlobalConfig::path(&config), "{not valid json").unwrap();
+        let loaded = GlobalConfig::load(&config);
+        assert!(loaded.mounts.is_empty());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 pub struct AppConfig {
@@ -79,6 +79,11 @@ impl GlobalConfig {
         file.write_all(json.as_bytes())
             .context("Failed to write global config contents")?;
         std::fs::rename(&tmp, &path).context("Failed to rename global config")?;
+        // `.mode(0o600)` only takes effect on O_CREAT; a stale tmp from a
+        // crashed earlier run keeps its old mode through truncate. Re-apply
+        // explicitly so the rename target is always 0o600.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .context("Failed to set permissions on global config")?;
         Ok(())
     }
 
@@ -315,5 +320,29 @@ mod tests {
         std::fs::write(GlobalConfig::path(&config), "{not valid json").unwrap();
         let loaded = GlobalConfig::load(&config);
         assert!(loaded.mounts.is_empty());
+    }
+
+    #[test]
+    fn global_config_save_overwrites_stale_tmp_with_0o600() {
+        // Simulate a stale tmp file from a crashed earlier save with
+        // permissive bits. The `.mode(0o600)` on OpenOptions only takes
+        // effect on O_CREAT, so without the explicit set_permissions after
+        // rename the final file would inherit the looser mode.
+        let dir = TempDir::new().unwrap();
+        let config = temp_config(&dir);
+        config.init().unwrap();
+        let tmp = GlobalConfig::path(&config).with_extension("tmp");
+        std::fs::write(&tmp, "stale").unwrap();
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let gc = GlobalConfig::default();
+        gc.save(&config).unwrap();
+
+        let mode = std::fs::metadata(GlobalConfig::path(&config))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "save must enforce 0o600 even over a stale tmp");
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -142,6 +142,14 @@ pub(crate) fn resolve_container_target(spec: &MountSpec, home_dir: &Path) -> Res
             spec.host
         )
     })?;
+    if rel.as_os_str().is_empty() {
+        // host == home_dir → "/home/ai-pod/" would mount on top of the seeded
+        // home volume root, hiding .claude/settings.json, .claude.json, etc.
+        anyhow::bail!(
+            "mount {} resolves to the home volume root; mount a sub-path instead",
+            spec.host
+        );
+    }
     Ok(format!("{}/{}", CONTAINER_HOME, rel.display()))
 }
 
@@ -157,8 +165,26 @@ pub(crate) fn resolve_container_target(spec: &MountSpec, home_dir: &Path) -> Res
 pub(crate) fn build_mount_args(home_dir: &Path, mounts: &[MountSpec]) -> Result<Vec<String>> {
     let mut out = Vec::with_capacity(mounts.len() * 2);
     for m in mounts {
-        let host = Path::new(&m.host);
-        if !host.exists() {
+        // Re-validate against the current $HOME and the current rule set so
+        // a stale or hand-edited `~/.ai-pod/config.json` can't bypass the
+        // checks. Failures warn-and-skip so one bad entry doesn't brick
+        // every launch.
+        let target = match crate::mount_cli::validate_spec(m, home_dir) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!(
+                    "{} mount {}: {}; skipping",
+                    "warning:".yellow().bold(),
+                    m.host,
+                    e
+                );
+                continue;
+            }
+        };
+        // symlink_metadata so a dangling symlink (target temporarily missing)
+        // still counts as present — `MountSpec`'s doc comment says symlinks
+        // are intentionally not resolved.
+        if Path::new(&m.host).symlink_metadata().is_err() {
             eprintln!(
                 "{} mount source {} does not exist; skipping",
                 "warning:".yellow().bold(),
@@ -166,7 +192,6 @@ pub(crate) fn build_mount_args(home_dir: &Path, mounts: &[MountSpec]) -> Result<
             );
             continue;
         }
-        let target = resolve_container_target(m, home_dir)?;
         let opts = if m.writable { "z" } else { "z,ro" };
         out.push("-v".to_string());
         out.push(format!("{}:{}:{}", m.host, target, opts));
@@ -1212,5 +1237,69 @@ mod tests {
         }];
         let args = build_mount_args(dir.path(), &mounts).unwrap();
         assert!(args.is_empty(), "missing host path should be skipped");
+    }
+
+    #[test]
+    fn resolve_container_target_rejects_home_root() {
+        // mount add ~ → empty rel → would produce "/home/ai-pod/" and
+        // shadow the seeded volume.
+        let spec = MountSpec {
+            host: "/home/user".into(),
+            container: None,
+            writable: false,
+        };
+        let err = resolve_container_target(&spec, Path::new("/home/user")).unwrap_err();
+        assert!(err.to_string().contains("home volume root"), "got: {err}");
+    }
+
+    #[test]
+    fn build_mount_args_warn_skips_outside_home_when_no_container() {
+        // Regression for the "stored mount bricks every launch" issue:
+        // a hand-synced config.json where `container == None` and `host`
+        // falls outside the *current* $HOME must not error — it should
+        // warn-skip like a missing host.
+        let dir = TempDir::new().unwrap();
+        let outside = dir.path().join("..").join("outside");
+        let mounts = vec![MountSpec {
+            host: outside.display().to_string(),
+            container: None,
+            writable: false,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert!(args.is_empty(), "invalid stored mount should be skipped");
+    }
+
+    #[test]
+    fn build_mount_args_warn_skips_invalid_stored_spec() {
+        // A spec that would have been rejected at `mount add` (here: `/` as
+        // host) but got past validation via hand-edited config.json must be
+        // dropped at launch.
+        let dir = TempDir::new().unwrap();
+        let mounts = vec![MountSpec {
+            host: "/".into(),
+            container: Some("/home/ai-pod/exploit".into()),
+            writable: false,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert!(args.is_empty(), "stored invalid host should be warn-skipped");
+    }
+
+    #[test]
+    fn build_mount_args_keeps_dangling_symlinks() {
+        // MountSpec doc explicitly says symlinks are not resolved, so a
+        // symlink whose target is temporarily missing should still mount.
+        use std::os::unix::fs::symlink;
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("link-to-nothing");
+        symlink(dir.path().join("does-not-exist"), &link).unwrap();
+        let host_str = link.to_string_lossy().to_string();
+        let mounts = vec![MountSpec {
+            host: host_str.clone(),
+            container: Some("/home/ai-pod/.claude/skills".into()),
+            writable: false,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert_eq!(args.len(), 2, "dangling symlink should still mount");
+        assert!(args[1].starts_with(&host_str));
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -4,7 +4,7 @@ use dialoguer;
 use std::path::Path;
 use std::process::Stdio;
 
-use crate::config::AppConfig;
+use crate::config::{AppConfig, GlobalConfig, MountSpec};
 use crate::runtime::ContainerRuntime;
 use crate::server::lifecycle::ProjectState;
 use crate::workspace::{
@@ -122,6 +122,54 @@ fn mask_mount_args(
         let vol = ensure_mask_volume(rt, workspace, image, dir)?;
         out.push("-v".to_string());
         out.push(format!("{}:/app/{}:Z", vol, dir));
+    }
+    Ok(out)
+}
+
+/// Resolve the in-container target path for a user-defined mount.
+///
+/// - If `spec.container` is set, returns it verbatim (already validated at `mount add`).
+/// - Otherwise, requires `spec.host` to be under `home_dir` and mirrors the
+///   path under `CONTAINER_HOME`. E.g. `~/.claude/skills` → `/home/ai-pod/.claude/skills`.
+pub(crate) fn resolve_container_target(spec: &MountSpec, home_dir: &Path) -> Result<String> {
+    if let Some(c) = &spec.container {
+        return Ok(c.clone());
+    }
+    let host = Path::new(&spec.host);
+    let rel = host.strip_prefix(home_dir).map_err(|_| {
+        anyhow::anyhow!(
+            "mount {} is outside $HOME; specify an explicit container path with host:container",
+            spec.host
+        )
+    })?;
+    Ok(format!("{}/{}", CONTAINER_HOME, rel.display()))
+}
+
+/// Build `-v` arg pairs for global host bind-mounts. Returned as a flat list
+/// (`-v`, `host:target:opts`, ...) ready to splice into the container run
+/// command after the workspace bind. Missing host paths are skipped with a
+/// stderr warning so a temporarily-absent host directory doesn't brick every
+/// project.
+///
+/// Uses the `:z` SELinux label (shared) to match the home-volume mount, so the
+/// host user retains access to e.g. `~/.claude/skills` after the container
+/// touches it. Read-only mounts get `:z,ro`.
+pub(crate) fn build_mount_args(home_dir: &Path, mounts: &[MountSpec]) -> Result<Vec<String>> {
+    let mut out = Vec::with_capacity(mounts.len() * 2);
+    for m in mounts {
+        let host = Path::new(&m.host);
+        if !host.exists() {
+            eprintln!(
+                "{} mount source {} does not exist; skipping",
+                "warning:".yellow().bold(),
+                m.host
+            );
+            continue;
+        }
+        let target = resolve_container_target(m, home_dir)?;
+        let opts = if m.writable { "z" } else { "z,ro" };
+        out.push("-v".to_string());
+        out.push(format!("{}:{}:{}", m.host, target, opts));
     }
     Ok(out)
 }
@@ -617,6 +665,8 @@ pub fn launch_container(
 
     let project_state = load_project_state(config, workspace);
     let mask_args = mask_mount_args(rt, workspace, image, &project_state.masked_directories)?;
+    let global = GlobalConfig::load(config);
+    let user_mount_args = build_mount_args(&config.home_dir, &global.mounts)?;
 
     let mut run_cmd = rt.command();
     run_cmd.args(["run", "--rm", "-it"]);
@@ -630,6 +680,9 @@ pub fn launch_container(
         "-v",
         &format!("{}:/app:Z", workspace_str),
     ]);
+    for arg in &user_mount_args {
+        run_cmd.arg(arg);
+    }
     for arg in &mask_args {
         run_cmd.arg(arg);
     }
@@ -707,6 +760,8 @@ pub fn run_in_container(
 
     let project_state = load_project_state(config, workspace);
     let mask_args = mask_mount_args(rt, workspace, image, &project_state.masked_directories)?;
+    let global = GlobalConfig::load(config);
+    let user_mount_args = build_mount_args(&config.home_dir, &global.mounts)?;
 
     let mut run_args: Vec<String> = vec![
         "run".into(),
@@ -721,6 +776,7 @@ pub fn run_in_container(
         "-v".into(),
         format!("{}:/app:Z", workspace_str),
     ]);
+    run_args.extend(user_mount_args);
     run_args.extend(mask_args);
     run_args.extend_from_slice(&[
         rt.add_host_arg(),
@@ -1047,5 +1103,114 @@ mod tests {
         assert_eq!(v["mcp"]["ai-pod"]["enabled"], true);
         assert_eq!(v["mcp"]["ai-pod"]["headers"]["X-Api-Key"], "k1");
         assert_eq!(v["mcp"]["ai-pod"]["headers"]["X-Ai-Pod-Session-Id"], "s2");
+    }
+
+    #[test]
+    fn resolve_container_target_uses_explicit_path() {
+        let spec = MountSpec {
+            host: "/whatever".into(),
+            container: Some("/run/secrets/key".into()),
+            writable: false,
+        };
+        let t = resolve_container_target(&spec, Path::new("/home/user")).unwrap();
+        assert_eq!(t, "/run/secrets/key");
+    }
+
+    #[test]
+    fn resolve_container_target_mirrors_home_paths() {
+        let spec = MountSpec {
+            host: "/home/user/.claude/skills".into(),
+            container: None,
+            writable: false,
+        };
+        let t = resolve_container_target(&spec, Path::new("/home/user")).unwrap();
+        assert_eq!(t, "/home/ai-pod/.claude/skills");
+    }
+
+    #[test]
+    fn resolve_container_target_errors_for_paths_outside_home() {
+        let spec = MountSpec {
+            host: "/etc/foo".into(),
+            container: None,
+            writable: false,
+        };
+        let err = resolve_container_target(&spec, Path::new("/home/user")).unwrap_err();
+        assert!(err.to_string().contains("outside $HOME"), "got: {err}");
+    }
+
+    #[test]
+    fn build_mount_args_emits_readonly_by_default() {
+        let dir = TempDir::new().unwrap();
+        let host_path = dir.path().join("skills");
+        std::fs::create_dir(&host_path).unwrap();
+        let host_str = host_path.to_string_lossy().to_string();
+        let mounts = vec![MountSpec {
+            host: host_str.clone(),
+            container: Some("/home/ai-pod/.claude/skills".into()),
+            writable: false,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert_eq!(
+            args,
+            vec![
+                "-v".to_string(),
+                format!("{}:/home/ai-pod/.claude/skills:z,ro", host_str),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_mount_args_emits_writable_when_flagged() {
+        let dir = TempDir::new().unwrap();
+        let host_path = dir.path().join("skills");
+        std::fs::create_dir(&host_path).unwrap();
+        let host_str = host_path.to_string_lossy().to_string();
+        let mounts = vec![MountSpec {
+            host: host_str.clone(),
+            container: Some("/home/ai-pod/.claude/skills".into()),
+            writable: true,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert_eq!(
+            args,
+            vec![
+                "-v".to_string(),
+                format!("{}:/home/ai-pod/.claude/skills:z", host_str),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_mount_args_resolves_home_relative_target() {
+        let dir = TempDir::new().unwrap();
+        let host_path = dir.path().join(".claude").join("skills");
+        std::fs::create_dir_all(&host_path).unwrap();
+        let host_str = host_path.to_string_lossy().to_string();
+        let mounts = vec![MountSpec {
+            host: host_str.clone(),
+            container: None,
+            writable: false,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert_eq!(
+            args,
+            vec![
+                "-v".to_string(),
+                format!("{}:/home/ai-pod/.claude/skills:z,ro", host_str),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_mount_args_skips_missing_host_paths() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        let mounts = vec![MountSpec {
+            host: missing.to_string_lossy().to_string(),
+            container: Some("/home/ai-pod/x".into()),
+            writable: false,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert!(args.is_empty(), "missing host path should be skipped");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod container;
 pub mod credentials;
 pub mod env_files_cli;
 pub mod image;
+pub mod mount_cli;
 pub mod runtime;
 pub mod server;
 pub mod update;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use ai_pod::{
-    cli, commands_cli, config, container, credentials, env_files_cli, image, runtime, server,
-    update, workspace,
+    cli, commands_cli, config, container, credentials, env_files_cli, image, mount_cli, runtime,
+    server, update, workspace,
 };
 
 use anyhow::{Context, Result};
@@ -8,7 +8,7 @@ use clap::Parser;
 use colored::Colorize;
 use std::path::Path;
 
-use cli::{AllowedAction, Cli, Command, CommandsAction, EnvFilesAction};
+use cli::{AllowedAction, Cli, Command, CommandsAction, EnvFilesAction, MountAction};
 use config::AppConfig;
 use runtime::ContainerRuntime;
 
@@ -333,6 +333,18 @@ async fn main() -> Result<()> {
                 Some(EnvFilesAction::Unignore { path }) => {
                     env_files_cli::run_unignore(&config, &workspace, path)?
                 }
+            }
+            return Ok(());
+        }
+        Some(Command::Mount { action }) => {
+            let config = AppConfig::new()?;
+            config.init()?;
+            match action {
+                MountAction::List => mount_cli::run_list(&config)?,
+                MountAction::Add { spec, writable } => {
+                    mount_cli::run_add(&config, spec, *writable)?
+                }
+                MountAction::Remove { host } => mount_cli::run_remove(&config, host)?,
             }
             return Ok(());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,8 +341,8 @@ async fn main() -> Result<()> {
             config.init()?;
             match action {
                 MountAction::List => mount_cli::run_list(&config)?,
-                MountAction::Add { spec, writable } => {
-                    mount_cli::run_add(&config, spec, *writable)?
+                MountAction::Add { spec, writable, yes } => {
+                    mount_cli::run_add(&config, spec, *writable, *yes)?
                 }
                 MountAction::Remove { host } => mount_cli::run_remove(&config, host)?,
             }

--- a/src/mount_cli.rs
+++ b/src/mount_cli.rs
@@ -163,6 +163,19 @@ pub(crate) fn validate_container_path(p: &str) -> Result<()> {
     Ok(())
 }
 
+/// Resolve `host` through any symlink chain and return the canonical
+/// absolute path as a string. Returns `None` if the path does not exist
+/// yet (canonicalize requires every component to exist) or if resolution
+/// fails for any other reason. The intentional design point of `MountSpec`
+/// is that the *stored* host string keeps the user's literal symlink
+/// path; this helper exists so the validators and warn-list can also see
+/// where that path *actually* points.
+pub(crate) fn canonical_host(host: &str) -> Option<String> {
+    std::fs::canonicalize(host)
+        .ok()
+        .map(|p| p.display().to_string())
+}
+
 /// Re-run all validators against a stored `MountSpec`, returning the resolved
 /// container target on success. Called both at `mount add` time (via
 /// [`parse_spec`]) and at every container launch by
@@ -170,6 +183,24 @@ pub(crate) fn validate_container_path(p: &str) -> Result<()> {
 /// can't bypass the security and footgun checks.
 pub(crate) fn validate_spec(spec: &MountSpec, home_dir: &Path) -> Result<String> {
     validate_host_path(&spec.host)?;
+    // If the host source resolves through symlinks to a different path,
+    // re-run the host-side string checks against the *resolved* target so
+    // a pre-existing `~/innocent → /etc` (or `→ /`) can't slip past. The
+    // stored `MountSpec.host` is left as the literal user input by design
+    // — this only gates the security/footgun rules. Skipped when the path
+    // doesn't exist yet; launch time gets another shot.
+    if let Some(canonical) = canonical_host(&spec.host) {
+        if canonical != spec.host {
+            validate_host_path(&canonical).map_err(|e| {
+                anyhow::anyhow!(
+                    "host path {} resolves via symlinks to {}: {}",
+                    spec.host,
+                    canonical,
+                    e
+                )
+            })?;
+        }
+    }
     if let Some(c) = &spec.container {
         validate_container_path(c)?;
     } else {
@@ -201,8 +232,25 @@ pub(crate) fn validate_spec(spec: &MountSpec, home_dir: &Path) -> Result<String>
 /// This is the place to teach ai-pod about new risky paths — every entry
 /// becomes an interactive confirmation gate at `mount add` time.
 pub(crate) fn warn_for_spec(spec: &MountSpec, target: &str, home_dir: &Path) -> Vec<String> {
+    let mut out = collect_host_warnings(&spec.host, target, home_dir);
+    if let Some(canonical) = canonical_host(&spec.host) {
+        if canonical != spec.host {
+            for w in collect_host_warnings(&canonical, target, home_dir) {
+                let tagged = format!(
+                    "[host {} resolves via symlinks to {}] {}",
+                    spec.host, canonical, w
+                );
+                if !out.iter().any(|existing| existing == &tagged) {
+                    out.push(tagged);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn collect_host_warnings(host: &str, target: &str, home_dir: &Path) -> Vec<String> {
     let mut out = Vec::new();
-    let host = spec.host.as_str();
 
     // 1. Well-known credential dirs / files under $HOME. These are the
     //    obvious sources of host-wide compromise if exposed to the agent.
@@ -244,6 +292,14 @@ pub(crate) fn warn_for_spec(spec: &MountSpec, target: &str, home_dir: &Path) -> 
         "/root",
         "/var/lib/docker",
         "/var/lib/containers",
+        // macOS canonicalizes /etc → /private/etc, /var/run → /private/var/run,
+        // /tmp → /private/tmp. Include the resolved forms so the
+        // symlink-resolution path of `warn_for_spec` lights up the same way
+        // as on Linux.
+        "/private/etc",
+        "/private/var/run",
+        "/private/var/lib/docker",
+        "/private/var/lib/containers",
     ];
     for sys in system_prefixes {
         if host == sys || host.starts_with(&format!("{}/", sys)) {
@@ -835,6 +891,52 @@ mod tests {
                 w
             );
         }
+    }
+
+    #[test]
+    fn validate_spec_rejects_symlink_to_filesystem_root() {
+        // The original #1 bypass: a `mount add ~/innocent` where the
+        // host path is itself a symlink to `/`. Without canonical-host
+        // re-validation this would have been accepted and podman would
+        // bind-mount the entire host filesystem.
+        use std::os::unix::fs::symlink;
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("innocent");
+        symlink("/", &link).unwrap();
+        let spec = MountSpec {
+            host: link.display().to_string(),
+            container: Some("/home/ai-pod/innocent".into()),
+            writable: false,
+        };
+        let err = validate_spec(&spec, dir.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("resolves via symlinks to"),
+            "expected canonical-resolved rejection, got: {}",
+            err
+        );
+        assert!(err.to_string().contains("filesystem root"), "got: {}", err);
+    }
+
+    #[test]
+    fn warn_fires_when_symlink_resolves_to_system_path() {
+        // `~/notes → /etc`: warn-list must look through the symlink, not
+        // just the literal path string.
+        use std::os::unix::fs::symlink;
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("notes");
+        symlink("/etc", &link).unwrap();
+        let spec = MountSpec {
+            host: link.display().to_string(),
+            container: Some("/home/ai-pod/notes".into()),
+            writable: false,
+        };
+        let w = warn_for_spec(&spec, "/home/ai-pod/notes", dir.path());
+        assert!(
+            w.iter().any(|m| m.contains("resolves via symlinks to")
+                && m.contains("system path")),
+            "expected canonical-tagged system-path warning, got: {:?}",
+            w
+        );
     }
 
     #[test]

--- a/src/mount_cli.rs
+++ b/src/mount_cli.rs
@@ -195,9 +195,159 @@ pub(crate) fn validate_spec(spec: &MountSpec, home_dir: &Path) -> Result<String>
     Ok(target)
 }
 
-pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()> {
+/// Path-specific warnings for `mount add`. Returns a list of human-readable
+/// reasons the mount is risky; an empty vec means "no concerns".
+///
+/// This is the place to teach ai-pod about new risky paths — every entry
+/// becomes an interactive confirmation gate at `mount add` time.
+pub(crate) fn warn_for_spec(spec: &MountSpec, target: &str, home_dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let host = spec.host.as_str();
+
+    // 1. Well-known credential dirs / files under $HOME. These are the
+    //    obvious sources of host-wide compromise if exposed to the agent.
+    let cred_subpaths = [
+        ".ssh",
+        ".aws",
+        ".gnupg",
+        ".config/gh",
+        ".config/gcloud",
+        ".config/git/credentials",
+        ".docker/config.json",
+        ".netrc",
+        ".kube",
+        ".password-store",
+    ];
+    for sub in cred_subpaths {
+        let p = home_dir.join(sub).display().to_string();
+        if host == p || host.starts_with(&format!("{}/", p)) {
+            out.push(format!(
+                "{} holds credentials — the in-container agent would gain full \
+                 access to them, including ability to authenticate as you to \
+                 remote services.",
+                host
+            ));
+            break;
+        }
+    }
+
+    // 2. System / runtime paths on the host. These either expose host-wide
+    //    state or hand the container a root-equivalent control plane.
+    let system_prefixes = [
+        "/etc",
+        "/var/run",
+        "/run",
+        "/proc",
+        "/sys",
+        "/dev",
+        "/boot",
+        "/root",
+        "/var/lib/docker",
+        "/var/lib/containers",
+    ];
+    for sys in system_prefixes {
+        if host == sys || host.starts_with(&format!("{}/", sys)) {
+            out.push(format!(
+                "{} is a host system path — mounting it can leak host secrets \
+                 (e.g. /etc/shadow) or grant container-escape primitives (e.g. \
+                 /var/run/docker.sock, /dev/*, /proc/*).",
+                host
+            ));
+            break;
+        }
+    }
+
+    // 3. ai-pod's own config dir. A writable mount here lets a compromised
+    //    container rewrite the global mount list for the next launch — a
+    //    confused-deputy escalation that compounds with all other risks.
+    let ai_pod = home_dir.join(".ai-pod").display().to_string();
+    if host == ai_pod || host.starts_with(&format!("{}/", ai_pod)) {
+        out.push(format!(
+            "{} is ai-pod's own config directory. Mounting it (especially \
+             writable) lets a container modify the global mount list and \
+             escalate to other host paths on the next launch.",
+            host
+        ));
+    }
+
+    // 4. Container target overrides files that ai-pod itself seeds. The
+    //    settings.json hooks carry $AI_POD_API_KEY; .claude.json holds the
+    //    MCP URL. Replacing either lets a hostile host file hijack the agent.
+    let seeded_files = [
+        "/home/ai-pod/.claude/settings.json",
+        "/home/ai-pod/.claude.json",
+        "/home/ai-pod/.claude/CLAUDE.md",
+        "/home/ai-pod/.gitconfig",
+    ];
+    if seeded_files.contains(&target) {
+        out.push(format!(
+            "Container target {} is seeded by ai-pod (Stop hook, MCP URL, \
+             api-key carrier). Overriding it can hijack the agent's host \
+             call-back or silently disable safety hooks.",
+            target
+        ));
+    }
+
+    // 5. Container target inside a system binary / library tree. The
+    //    runtime-settings Stop hook is a `curl` invocation; replacing the
+    //    binary or libc underneath the agent is full code execution as the
+    //    `ai-pod` user with the api key in env.
+    let bin_prefixes = [
+        "/usr/bin",
+        "/usr/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/bin",
+        "/sbin",
+        "/lib",
+        "/lib64",
+        "/usr/lib",
+        "/usr/lib64",
+        "/boot",
+    ];
+    for bp in bin_prefixes {
+        if target == bp || target.starts_with(&format!("{}/", bp)) {
+            out.push(format!(
+                "Container target {} shadows a system binary/library path. \
+                 The agent will execute whatever host file you mount there.",
+                target
+            ));
+            break;
+        }
+    }
+
+    out
+}
+
+pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool, assume_yes: bool) -> Result<()> {
     let spec = parse_spec(spec_str, writable, &config.home_dir)?;
     let target = crate::container::resolve_container_target(&spec, &config.home_dir)?;
+
+    let warnings = warn_for_spec(&spec, &target, &config.home_dir);
+    if !warnings.is_empty() {
+        eprintln!(
+            "{} this mount is on ai-pod's risky-path warn-list:",
+            "warning:".yellow().bold()
+        );
+        for w in &warnings {
+            eprintln!("  • {}", w);
+        }
+        if !assume_yes {
+            let confirm = dialoguer::Confirm::new()
+                .with_prompt(format!(
+                    "Proceed with mount {} → {} ({})?",
+                    spec.host,
+                    target,
+                    if spec.writable { "rw" } else { "ro" }
+                ))
+                .default(false)
+                .interact()
+                .unwrap_or(false);
+            if !confirm {
+                anyhow::bail!("Mount cancelled by user");
+            }
+        }
+    }
 
     let mut gc = GlobalConfig::load(config);
 
@@ -526,7 +676,7 @@ mod tests {
     fn run_add_rejects_no_container_outside_home() {
         let dir = TempDir::new().unwrap();
         let config = make_config(dir.path());
-        let err = run_add(&config, "/etc/foo", false).unwrap_err();
+        let err = run_add(&config, "/etc/foo", false, true).unwrap_err();
         assert!(err.to_string().contains("outside $HOME"));
     }
 
@@ -536,7 +686,7 @@ mod tests {
         let config = make_config(dir.path());
         std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
-        run_add(&config, "~/.claude/skills", false).unwrap();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1);
         assert_eq!(
@@ -560,7 +710,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let config = make_config(dir.path());
         std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
-        run_add(&config, "~/.claude/skills", false).unwrap();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
 
         run_remove(&config, "~/.claude/skills/").unwrap();
         let gc = GlobalConfig::load(&config);
@@ -573,8 +723,8 @@ mod tests {
         let config = make_config(dir.path());
         std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
-        run_add(&config, "~/.claude/skills", false).unwrap();
-        run_add(&config, "~/.claude/skills", false).unwrap();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1, "duplicate host should not be added");
         assert!(!gc.mounts[0].writable);
@@ -586,8 +736,8 @@ mod tests {
         let config = make_config(dir.path());
         std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
-        run_add(&config, "~/.claude/skills", false).unwrap();
-        let err = run_add(&config, "~/.claude/skills", true).unwrap_err();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
+        let err = run_add(&config, "~/.claude/skills", true, true).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("already mounted"), "got: {msg}");
         assert!(msg.contains("remove"), "should hint to remove first: {msg}");
@@ -595,6 +745,138 @@ mod tests {
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1);
         assert!(!gc.mounts[0].writable, "stored entry should be unchanged");
+    }
+
+    fn spec(host: &str, container: Option<&str>) -> MountSpec {
+        MountSpec {
+            host: host.to_string(),
+            container: container.map(|c| c.to_string()),
+            writable: false,
+        }
+    }
+
+    #[test]
+    fn warn_flags_ssh_aws_gnupg_under_home() {
+        let home = Path::new("/H");
+        for sub in [".ssh", ".aws", ".gnupg", ".config/gh", ".netrc"] {
+            let host = format!("/H/{}", sub);
+            let target = format!("/home/ai-pod/{}", sub);
+            let w = warn_for_spec(&spec(&host, Some(&target)), &target, home);
+            assert!(!w.is_empty(), "{} should warn", sub);
+            assert!(w.iter().any(|m| m.contains("credentials")), "got {:?}", w);
+        }
+    }
+
+    #[test]
+    fn warn_flags_system_host_paths() {
+        let home = Path::new("/H");
+        for sys in [
+            "/etc/hosts",
+            "/var/run/docker.sock",
+            "/dev/null",
+            "/proc/1",
+            "/sys/kernel",
+            "/root/x",
+        ] {
+            let w = warn_for_spec(&spec(sys, Some("/x")), "/x", home);
+            assert!(!w.is_empty(), "{} should warn", sys);
+            assert!(w.iter().any(|m| m.contains("system path")), "got {:?}", w);
+        }
+    }
+
+    #[test]
+    fn warn_flags_ai_pod_self_mount() {
+        let home = Path::new("/H");
+        let w = warn_for_spec(&spec("/H/.ai-pod", None), "/home/ai-pod/.ai-pod", home);
+        assert!(w.iter().any(|m| m.contains("ai-pod's own")), "got {:?}", w);
+
+        let w = warn_for_spec(
+            &spec("/H/.ai-pod/config.json", Some("/home/ai-pod/cfg")),
+            "/home/ai-pod/cfg",
+            home,
+        );
+        assert!(w.iter().any(|m| m.contains("ai-pod's own")), "got {:?}", w);
+    }
+
+    #[test]
+    fn warn_flags_seeded_target_files() {
+        let home = Path::new("/H");
+        for t in [
+            "/home/ai-pod/.claude/settings.json",
+            "/home/ai-pod/.claude.json",
+            "/home/ai-pod/.claude/CLAUDE.md",
+        ] {
+            let w = warn_for_spec(&spec("/H/x", Some(t)), t, home);
+            assert!(
+                w.iter().any(|m| m.contains("seeded by ai-pod")),
+                "{} should warn, got {:?}",
+                t,
+                w
+            );
+        }
+    }
+
+    #[test]
+    fn warn_flags_binary_shadow_targets() {
+        let home = Path::new("/H");
+        for t in [
+            "/usr/bin/curl",
+            "/bin/sh",
+            "/sbin/init",
+            "/usr/local/bin/foo",
+            "/lib/x86_64-linux-gnu/libc.so.6",
+            "/boot/vmlinuz",
+        ] {
+            let w = warn_for_spec(&spec("/H/x", Some(t)), t, home);
+            assert!(
+                w.iter().any(|m| m.contains("system binary/library")),
+                "{} should warn, got {:?}",
+                t,
+                w
+            );
+        }
+    }
+
+    #[test]
+    fn warn_silent_on_benign_skills_mount() {
+        let home = Path::new("/H");
+        let w = warn_for_spec(
+            &spec("/H/.claude/skills", None),
+            "/home/ai-pod/.claude/skills",
+            home,
+        );
+        assert!(w.is_empty(), "skills mount should be silent, got {:?}", w);
+    }
+
+    #[test]
+    fn run_add_aborts_risky_mount_without_yes() {
+        // Non-interactive: dialoguer::Confirm falls back to its default
+        // (false), so the add must bail rather than succeed silently.
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        let ssh = dir.path().join(".ssh");
+        std::fs::create_dir_all(&ssh).unwrap();
+
+        let err = run_add(&config, &ssh.display().to_string(), false, false).unwrap_err();
+        assert!(
+            err.to_string().contains("cancelled"),
+            "expected cancellation, got: {}",
+            err
+        );
+        let gc = GlobalConfig::load(&config);
+        assert!(gc.mounts.is_empty(), "risky mount must not be stored");
+    }
+
+    #[test]
+    fn run_add_allows_risky_mount_with_yes() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        let ssh = dir.path().join(".ssh");
+        std::fs::create_dir_all(&ssh).unwrap();
+
+        run_add(&config, &ssh.display().to_string(), false, true).unwrap();
+        let gc = GlobalConfig::load(&config);
+        assert_eq!(gc.mounts.len(), 1);
     }
 
     #[test]
@@ -606,8 +888,8 @@ mod tests {
         let a = dir.path().join("a").display().to_string();
         let b = dir.path().join("b").display().to_string();
 
-        run_add(&config, &format!("{}:/home/ai-pod/shared", a), false).unwrap();
-        let err = run_add(&config, &format!("{}:/home/ai-pod/shared", b), false).unwrap_err();
+        run_add(&config, &format!("{}:/home/ai-pod/shared", a), false, true).unwrap();
+        let err = run_add(&config, &format!("{}:/home/ai-pod/shared", b), false, true).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("already used"), "got: {msg}");
 

--- a/src/mount_cli.rs
+++ b/src/mount_cli.rs
@@ -15,33 +15,66 @@ const CONTAINER_HOME: &str = "/home/ai-pod";
 const RESERVED_CONTAINER_PREFIXES: &[&str] =
     &["/proc", "/sys", "/dev", "/etc", "/tmp", "/run", "/var/run"];
 
+/// Exact container paths that ai-pod itself seeds into the home volume
+/// (see `seed_home_volume` in container.rs). Mounting a host path on top of
+/// any of these would silently replace ai-pod's Stop hook / MCP wiring /
+/// opencode plugin and produce a container that looks fine but no longer
+/// communicates with the host. Sub-paths are allowed (e.g.
+/// `/home/ai-pod/.claude/skills` is the advertised use case).
+const SEEDED_CONTAINER_TARGETS: &[&str] = &[
+    "/home/ai-pod/.claude",
+    "/home/ai-pod/.config/opencode/plugins",
+];
+
 /// Parse a user-provided `host[:container]` spec. The host portion is
-/// tilde-expanded against `home_dir`.
+/// tilde-expanded against `home_dir`; both halves are normalized (trailing
+/// slashes trimmed) before validation so dedup and the seeded-path /
+/// reserved-prefix checks can't be bypassed by writing `~/x/` vs `~/x` or
+/// `/home/ai-pod/` vs `/home/ai-pod`.
 pub(crate) fn parse_spec(s: &str, writable: bool, home_dir: &Path) -> Result<MountSpec> {
-    let (host_raw, container) = match s.split_once(':') {
-        Some((h, c)) => (h, Some(c.to_string())),
+    let (host_raw, container_raw) = match s.split_once(':') {
+        Some((h, c)) => (h, Some(c)),
         None => (s, None),
     };
-    let host = expand_tilde(host_raw, home_dir);
-    validate_host_path(&host)?;
-    if let Some(c) = &container {
-        validate_container_path(c)?;
-    }
-    Ok(MountSpec {
+    let host = normalize_host(host_raw, home_dir);
+    let container = container_raw.map(normalize_container);
+    let spec = MountSpec {
         host,
         container,
         writable,
-    })
+    };
+    validate_spec(&spec, home_dir)?;
+    Ok(spec)
 }
 
-pub(crate) fn expand_tilde(s: &str, home_dir: &Path) -> String {
-    if s == "~" {
-        return home_dir.display().to_string();
+/// Expand a leading `~` / `~/` against `home_dir` and strip any trailing
+/// slashes. Used as the single normalization point for both `mount add` and
+/// `mount remove` so they look at exactly the same string.
+pub(crate) fn normalize_host(s: &str, home_dir: &Path) -> String {
+    let expanded = if s == "~" {
+        home_dir.display().to_string()
+    } else if let Some(rest) = s.strip_prefix("~/") {
+        home_dir.join(rest).display().to_string()
+    } else {
+        s.to_string()
+    };
+    trim_trailing_slashes(&expanded)
+}
+
+pub(crate) fn normalize_container(s: &str) -> String {
+    trim_trailing_slashes(s)
+}
+
+fn trim_trailing_slashes(s: &str) -> String {
+    let trimmed = s.trim_end_matches('/');
+    if trimmed.is_empty() {
+        // Preserve "/" so the host-root check in `validate_host_path` can
+        // reject it explicitly rather than producing a misleading
+        // "must not be empty" error.
+        "/".to_string()
+    } else {
+        trimmed.to_string()
     }
-    if let Some(rest) = s.strip_prefix("~/") {
-        return home_dir.join(rest).display().to_string();
-    }
-    s.to_string()
 }
 
 pub(crate) fn validate_host_path(p: &str) -> Result<()> {
@@ -51,6 +84,19 @@ pub(crate) fn validate_host_path(p: &str) -> Result<()> {
     if p.contains('\0') {
         anyhow::bail!("Host path must not contain null bytes");
     }
+    if p.contains(':') {
+        // The `-v` arg uses `:` to separate host:container:opts. A host path
+        // with a `:` either smuggles in mount options (e.g. host
+        // `/x:rw,suid`) or is silently truncated to the first colon, both
+        // of which surprise the user.
+        anyhow::bail!("Host path must not contain ':' (collides with -v separator)");
+    }
+    if p == "/" {
+        anyhow::bail!(
+            "Host path '/' (filesystem root) is not allowed; mounting it would expose \
+             the entire host filesystem to the container"
+        );
+    }
     let path = Path::new(p);
     if !path.is_absolute() {
         anyhow::bail!(
@@ -58,7 +104,10 @@ pub(crate) fn validate_host_path(p: &str) -> Result<()> {
             p
         );
     }
-    if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
         anyhow::bail!("Host path must not contain '..' segments");
     }
     Ok(())
@@ -71,11 +120,17 @@ pub(crate) fn validate_container_path(p: &str) -> Result<()> {
     if p.contains('\0') {
         anyhow::bail!("Container path must not contain null bytes");
     }
+    if p.contains(':') {
+        anyhow::bail!("Container path must not contain ':' (collides with -v separator)");
+    }
     let path = Path::new(p);
     if !path.is_absolute() {
         anyhow::bail!("Container path must be absolute (got {})", p);
     }
-    if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
         anyhow::bail!("Container path must not contain '..' segments");
     }
     if p == "/" {
@@ -95,17 +150,34 @@ pub(crate) fn validate_container_path(p: &str) -> Result<()> {
             anyhow::bail!("Container target {} is reserved", p);
         }
     }
+    for seeded in SEEDED_CONTAINER_TARGETS {
+        if p == *seeded {
+            anyhow::bail!(
+                "Container target {} is seeded by ai-pod and would silently shadow \
+                 the in-container settings. Mount a sub-path instead (e.g. {}/skills).",
+                p,
+                p
+            );
+        }
+    }
     Ok(())
 }
 
-pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()> {
-    let spec = parse_spec(spec_str, writable, &config.home_dir)?;
-
-    // If no explicit container path is given, ensure host is under $HOME so
-    // the launch-time resolver won't fail later.
-    if spec.container.is_none() {
+/// Re-run all validators against a stored `MountSpec`, returning the resolved
+/// container target on success. Called both at `mount add` time (via
+/// [`parse_spec`]) and at every container launch by
+/// `container::build_mount_args` so that a hand-edited `~/.ai-pod/config.json`
+/// can't bypass the security and footgun checks.
+pub(crate) fn validate_spec(spec: &MountSpec, home_dir: &Path) -> Result<String> {
+    validate_host_path(&spec.host)?;
+    if let Some(c) = &spec.container {
+        validate_container_path(c)?;
+    } else {
+        // Auto-mode: host must be under $HOME so the resolver can mirror it.
+        // We check here (in addition to inside `resolve_container_target`)
+        // so the error is actionable at `mount add` time.
         let host = Path::new(&spec.host);
-        if host.strip_prefix(&config.home_dir).is_err() {
+        if host.strip_prefix(home_dir).is_err() {
             anyhow::bail!(
                 "Host path {} is outside $HOME. Supply an explicit container path: \
                  ai-pod mount add {}:<container-path>",
@@ -114,16 +186,58 @@ pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()>
             );
         }
     }
+    let target = crate::container::resolve_container_target(spec, home_dir)?;
+    // Re-validate the *resolved* target so the seeded-path / reserved /
+    // /home/ai-pod-root checks apply to auto-mode mounts too — e.g.
+    // `mount add ~/.claude` resolves to `/home/ai-pod/.claude` and gets
+    // rejected as a seeded prefix.
+    validate_container_path(&target)?;
+    Ok(target)
+}
+
+pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()> {
+    let spec = parse_spec(spec_str, writable, &config.home_dir)?;
+    let target = crate::container::resolve_container_target(&spec, &config.home_dir)?;
 
     let mut gc = GlobalConfig::load(config);
-    if !gc.add(spec.clone()) {
+
+    if let Some(existing) = gc.mounts.iter().find(|m| m.host == spec.host) {
+        if existing.writable != spec.writable {
+            anyhow::bail!(
+                "{} is already mounted as {}. Run `ai-pod mount remove {}` first, \
+                 then re-add{}.",
+                spec.host,
+                if existing.writable { "rw" } else { "ro" },
+                spec.host,
+                if spec.writable { " with --writable" } else { "" }
+            );
+        }
         println!("{} {}", "Already mounted:".yellow(), spec.host);
         return Ok(());
     }
+
+    for existing in &gc.mounts {
+        let existing_target = match crate::container::resolve_container_target(
+            existing,
+            &config.home_dir,
+        ) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if existing_target == target {
+            anyhow::bail!(
+                "Container target {} is already used by mount {}; pick a different \
+                 container path with `ai-pod mount add {}:<other-path>`.",
+                target,
+                existing.host,
+                spec.host
+            );
+        }
+    }
+
+    gc.add(spec.clone());
     gc.save(config)?;
 
-    let target = crate::container::resolve_container_target(&spec, &config.home_dir)
-        .unwrap_or_else(|_| "(invalid)".to_string());
     println!(
         "{} {} → {} ({})",
         "Mounted:".green().bold(),
@@ -132,19 +246,19 @@ pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()>
         if spec.writable { "rw" } else { "ro" }
     );
 
-    warn_if_unreadable(&spec)?;
+    warn_if_unreadable(&spec);
     Ok(())
 }
 
 pub fn run_remove(config: &AppConfig, host: &str) -> Result<()> {
-    let expanded = expand_tilde(host, &config.home_dir);
+    let normalized = normalize_host(host, &config.home_dir);
     let mut gc = GlobalConfig::load(config);
-    if !gc.remove(&expanded) {
-        println!("{} {}", "Not mounted:".yellow(), expanded);
+    if !gc.remove(&normalized) {
+        println!("{} {}", "Not mounted:".yellow(), normalized);
         return Ok(());
     }
     gc.save(config)?;
-    println!("{} {}", "Unmounted:".green().bold(), expanded);
+    println!("{} {}", "Unmounted:".green().bold(), normalized);
     Ok(())
 }
 
@@ -162,7 +276,7 @@ pub fn run_list(config: &AppConfig) -> Result<()> {
         let target = crate::container::resolve_container_target(m, &config.home_dir)
             .unwrap_or_else(|_| "(invalid)".to_string());
         let mode = if m.writable { "rw" } else { "ro" };
-        let exists = if Path::new(&m.host).exists() {
+        let exists = if Path::new(&m.host).symlink_metadata().is_ok() {
             ""
         } else {
             "  (missing — will be skipped at launch)"
@@ -172,21 +286,21 @@ pub fn run_list(config: &AppConfig) -> Result<()> {
     Ok(())
 }
 
-/// One-line warning for `mount add` when the host file is mode-restricted in a
-/// way that the in-container `ai-pod` user is unlikely to be able to read it.
-/// Best-effort; silent on any error.
-fn warn_if_unreadable(spec: &MountSpec) -> Result<()> {
+/// One-line warning for `mount add` when the host file is mode-restricted in
+/// a way that the in-container `ai-pod` user is unlikely to be able to read
+/// it. Best-effort; silent on any error.
+fn warn_if_unreadable(spec: &MountSpec) {
     let path = Path::new(&spec.host);
     let meta = match std::fs::metadata(path) {
         Ok(m) => m,
-        Err(_) => return Ok(()),
+        Err(_) => return,
     };
     if !meta.is_file() {
-        return Ok(());
+        return;
     }
     let mode = meta.permissions().mode() & 0o777;
     if mode & 0o004 != 0 {
-        return Ok(());
+        return;
     }
     eprintln!(
         "{} {} has mode {:o}; the container user may not be able to read it under \
@@ -196,7 +310,6 @@ fn warn_if_unreadable(spec: &MountSpec) -> Result<()> {
         mode,
         spec.host
     );
-    Ok(())
 }
 
 #[cfg(test)]
@@ -204,11 +317,23 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn make_config(home: &Path) -> AppConfig {
+        let config_dir = home.join(".ai-pod");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        AppConfig {
+            runtime_settings: config_dir.join("runtime-settings.json"),
+            config_dir,
+            home_dir: home.to_path_buf(),
+        }
+    }
+
     #[test]
     fn parse_spec_host_only() {
         let dir = TempDir::new().unwrap();
-        let spec = parse_spec("/abs/path", false, dir.path()).unwrap();
-        assert_eq!(spec.host, "/abs/path");
+        std::fs::create_dir_all(dir.path().join("abs/path")).unwrap();
+        let host = dir.path().join("abs/path");
+        let spec = parse_spec(&host.display().to_string(), false, dir.path()).unwrap();
+        assert_eq!(spec.host, host.display().to_string());
         assert_eq!(spec.container, None);
         assert!(!spec.writable);
     }
@@ -263,7 +388,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         for r in ["/proc", "/proc/sys", "/sys", "/dev/null", "/etc/passwd"] {
             let err = parse_spec(&format!("/host:{}", r), false, dir.path()).unwrap_err();
-            assert!(err.to_string().contains("reserved"), "target {} should be reserved", r);
+            assert!(
+                err.to_string().contains("reserved"),
+                "target {} should be reserved",
+                r
+            );
         }
     }
 
@@ -282,25 +411,121 @@ mod tests {
     }
 
     #[test]
-    fn expand_tilde_only_at_start() {
+    fn parse_spec_rejects_filesystem_root_host() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/:/host", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("filesystem root"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_filesystem_root_host_alone() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("filesystem root"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_colon_smuggling_in_container() {
+        // `split_once(':')` puts everything after the first colon into the
+        // container portion, so this would otherwise smuggle `rw,suid` into
+        // the podman -v opts.
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/tmp/x:/foo:rw,suid", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("':'"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_normalizes_trailing_slash_in_host() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let spec = parse_spec("~/x/", false, home).unwrap();
+        assert_eq!(spec.host, home.join("x").display().to_string());
+        assert!(!spec.host.ends_with('/'));
+    }
+
+    #[test]
+    fn parse_spec_normalizes_trailing_slash_in_container() {
+        let dir = TempDir::new().unwrap();
+        let spec = parse_spec("/host:/foo/bar/", false, dir.path()).unwrap();
+        assert_eq!(spec.container.as_deref(), Some("/foo/bar"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_trailing_slash_bypass_of_container_home() {
+        let dir = TempDir::new().unwrap();
+        // Without normalization, "/home/ai-pod/" would slip past the
+        // `p == CONTAINER_HOME` exact-match check.
+        let err = parse_spec("/host:/home/ai-pod/", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("home volume"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_trailing_slash_bypass_of_app() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/host:/app/", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("/app"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_trailing_slash_bypass_of_reserved() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/host:/etc/", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("reserved"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_seeded_dot_claude() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/host:/home/ai-pod/.claude", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("seeded"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_seeded_opencode_plugins() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec(
+            "/host:/home/ai-pod/.config/opencode/plugins",
+            false,
+            dir.path(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("seeded"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_auto_mode_dot_claude() {
+        // `~/.claude` in auto-mode resolves to `/home/ai-pod/.claude`, which
+        // is a seeded prefix. Without re-validating the resolved target,
+        // this would silently shadow the Stop hook + MCP wiring.
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        let err = parse_spec("~/.claude", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("seeded"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_auto_mode_home_root() {
+        // `mount add ~` resolves to `/home/ai-pod`, shadowing the home volume.
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("~", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("home volume"), "got: {err}");
+    }
+
+    #[test]
+    fn normalize_host_only_at_start() {
         let home = Path::new("/H");
-        assert_eq!(expand_tilde("~", home), "/H");
-        assert_eq!(expand_tilde("~/foo", home), "/H/foo");
-        assert_eq!(expand_tilde("/abs/~/foo", home), "/abs/~/foo");
-        assert_eq!(expand_tilde("/abs", home), "/abs");
+        assert_eq!(normalize_host("~", home), "/H");
+        assert_eq!(normalize_host("~/foo", home), "/H/foo");
+        assert_eq!(normalize_host("~/foo/", home), "/H/foo");
+        assert_eq!(normalize_host("/abs/~/foo", home), "/abs/~/foo");
+        assert_eq!(normalize_host("/abs", home), "/abs");
+        assert_eq!(normalize_host("/", home), "/");
     }
 
     #[test]
     fn run_add_rejects_no_container_outside_home() {
         let dir = TempDir::new().unwrap();
-        let home = dir.path().to_path_buf();
-        let config_dir = home.join(".ai-pod");
-        std::fs::create_dir_all(&config_dir).unwrap();
-        let config = AppConfig {
-            runtime_settings: config_dir.join("runtime-settings.json"),
-            config_dir,
-            home_dir: home,
-        };
+        let config = make_config(dir.path());
         let err = run_add(&config, "/etc/foo", false).unwrap_err();
         assert!(err.to_string().contains("outside $HOME"));
     }
@@ -308,27 +533,20 @@ mod tests {
     #[test]
     fn run_add_and_remove_round_trip() {
         let dir = TempDir::new().unwrap();
-        let home = dir.path().to_path_buf();
-        let config_dir = home.join(".ai-pod");
-        std::fs::create_dir_all(&config_dir).unwrap();
-        let config = AppConfig {
-            runtime_settings: config_dir.join("runtime-settings.json"),
-            config_dir,
-            home_dir: home.clone(),
-        };
-        std::fs::create_dir_all(home.join(".claude/skills")).unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
         run_add(&config, "~/.claude/skills", false).unwrap();
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1);
         assert_eq!(
             gc.mounts[0].host,
-            home.join(".claude/skills").display().to_string()
+            dir.path().join(".claude/skills").display().to_string()
         );
 
         run_remove(
             &config,
-            &home.join(".claude/skills").display().to_string(),
+            &dir.path().join(".claude/skills").display().to_string(),
         )
         .unwrap();
         let gc = GlobalConfig::load(&config);
@@ -336,22 +554,64 @@ mod tests {
     }
 
     #[test]
-    fn run_add_dedups_by_host() {
+    fn run_remove_normalizes_trailing_slash() {
+        // Symmetric with parse_spec normalization: a user who types
+        // `~/x/` for `mount remove` should find the entry stored as `~/x`.
         let dir = TempDir::new().unwrap();
-        let home = dir.path().to_path_buf();
-        let config_dir = home.join(".ai-pod");
-        std::fs::create_dir_all(&config_dir).unwrap();
-        let config = AppConfig {
-            runtime_settings: config_dir.join("runtime-settings.json"),
-            config_dir,
-            home_dir: home.clone(),
-        };
-        std::fs::create_dir_all(home.join(".claude/skills")).unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
+        run_add(&config, "~/.claude/skills", false).unwrap();
+
+        run_remove(&config, "~/.claude/skills/").unwrap();
+        let gc = GlobalConfig::load(&config);
+        assert!(gc.mounts.is_empty(), "remove should find the entry");
+    }
+
+    #[test]
+    fn run_add_dedups_by_host_when_writable_matches() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
         run_add(&config, "~/.claude/skills", false).unwrap();
-        run_add(&config, "~/.claude/skills", true).unwrap();
+        run_add(&config, "~/.claude/skills", false).unwrap();
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1, "duplicate host should not be added");
-        assert!(!gc.mounts[0].writable, "first add wins");
+        assert!(!gc.mounts[0].writable);
+    }
+
+    #[test]
+    fn run_add_errors_on_writable_mismatch() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
+
+        run_add(&config, "~/.claude/skills", false).unwrap();
+        let err = run_add(&config, "~/.claude/skills", true).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("already mounted"), "got: {msg}");
+        assert!(msg.contains("remove"), "should hint to remove first: {msg}");
+
+        let gc = GlobalConfig::load(&config);
+        assert_eq!(gc.mounts.len(), 1);
+        assert!(!gc.mounts[0].writable, "stored entry should be unchanged");
+    }
+
+    #[test]
+    fn run_add_rejects_colliding_container_target() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join("a")).unwrap();
+        std::fs::create_dir_all(dir.path().join("b")).unwrap();
+        let a = dir.path().join("a").display().to_string();
+        let b = dir.path().join("b").display().to_string();
+
+        run_add(&config, &format!("{}:/home/ai-pod/shared", a), false).unwrap();
+        let err = run_add(&config, &format!("{}:/home/ai-pod/shared", b), false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("already used"), "got: {msg}");
+
+        let gc = GlobalConfig::load(&config);
+        assert_eq!(gc.mounts.len(), 1, "colliding mount should not be stored");
     }
 }

--- a/src/mount_cli.rs
+++ b/src/mount_cli.rs
@@ -1,0 +1,357 @@
+//! Host-side `ai-pod mount` subcommand: add, remove, list bind-mounts that
+//! are applied to every ai-pod container launch.
+
+use anyhow::Result;
+use colored::Colorize;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use crate::config::{AppConfig, GlobalConfig, MountSpec};
+
+const CONTAINER_HOME: &str = "/home/ai-pod";
+
+/// Container path prefixes that would break the container if shadowed by a
+/// user mount.
+const RESERVED_CONTAINER_PREFIXES: &[&str] =
+    &["/proc", "/sys", "/dev", "/etc", "/tmp", "/run", "/var/run"];
+
+/// Parse a user-provided `host[:container]` spec. The host portion is
+/// tilde-expanded against `home_dir`.
+pub(crate) fn parse_spec(s: &str, writable: bool, home_dir: &Path) -> Result<MountSpec> {
+    let (host_raw, container) = match s.split_once(':') {
+        Some((h, c)) => (h, Some(c.to_string())),
+        None => (s, None),
+    };
+    let host = expand_tilde(host_raw, home_dir);
+    validate_host_path(&host)?;
+    if let Some(c) = &container {
+        validate_container_path(c)?;
+    }
+    Ok(MountSpec {
+        host,
+        container,
+        writable,
+    })
+}
+
+pub(crate) fn expand_tilde(s: &str, home_dir: &Path) -> String {
+    if s == "~" {
+        return home_dir.display().to_string();
+    }
+    if let Some(rest) = s.strip_prefix("~/") {
+        return home_dir.join(rest).display().to_string();
+    }
+    s.to_string()
+}
+
+pub(crate) fn validate_host_path(p: &str) -> Result<()> {
+    if p.is_empty() {
+        anyhow::bail!("Host path must not be empty");
+    }
+    if p.contains('\0') {
+        anyhow::bail!("Host path must not contain null bytes");
+    }
+    let path = Path::new(p);
+    if !path.is_absolute() {
+        anyhow::bail!(
+            "Host path must be absolute (got {}). Use ~/path or /absolute/path.",
+            p
+        );
+    }
+    if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+        anyhow::bail!("Host path must not contain '..' segments");
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_container_path(p: &str) -> Result<()> {
+    if p.is_empty() {
+        anyhow::bail!("Container path must not be empty");
+    }
+    if p.contains('\0') {
+        anyhow::bail!("Container path must not contain null bytes");
+    }
+    let path = Path::new(p);
+    if !path.is_absolute() {
+        anyhow::bail!("Container path must be absolute (got {})", p);
+    }
+    if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+        anyhow::bail!("Container path must not contain '..' segments");
+    }
+    if p == "/" {
+        anyhow::bail!("Container path '/' is not a valid mount target");
+    }
+    if p == CONTAINER_HOME {
+        anyhow::bail!(
+            "Container target {} would shadow the entire home volume; pick a sub-path",
+            CONTAINER_HOME
+        );
+    }
+    if p == "/app" || p.starts_with("/app/") {
+        anyhow::bail!("Container target must not be under /app (workspace bind)");
+    }
+    for reserved in RESERVED_CONTAINER_PREFIXES {
+        if p == *reserved || p.starts_with(&format!("{}/", reserved)) {
+            anyhow::bail!("Container target {} is reserved", p);
+        }
+    }
+    Ok(())
+}
+
+pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()> {
+    let spec = parse_spec(spec_str, writable, &config.home_dir)?;
+
+    // If no explicit container path is given, ensure host is under $HOME so
+    // the launch-time resolver won't fail later.
+    if spec.container.is_none() {
+        let host = Path::new(&spec.host);
+        if host.strip_prefix(&config.home_dir).is_err() {
+            anyhow::bail!(
+                "Host path {} is outside $HOME. Supply an explicit container path: \
+                 ai-pod mount add {}:<container-path>",
+                spec.host,
+                spec.host
+            );
+        }
+    }
+
+    let mut gc = GlobalConfig::load(config);
+    if !gc.add(spec.clone()) {
+        println!("{} {}", "Already mounted:".yellow(), spec.host);
+        return Ok(());
+    }
+    gc.save(config)?;
+
+    let target = crate::container::resolve_container_target(&spec, &config.home_dir)
+        .unwrap_or_else(|_| "(invalid)".to_string());
+    println!(
+        "{} {} → {} ({})",
+        "Mounted:".green().bold(),
+        spec.host,
+        target,
+        if spec.writable { "rw" } else { "ro" }
+    );
+
+    warn_if_unreadable(&spec)?;
+    Ok(())
+}
+
+pub fn run_remove(config: &AppConfig, host: &str) -> Result<()> {
+    let expanded = expand_tilde(host, &config.home_dir);
+    let mut gc = GlobalConfig::load(config);
+    if !gc.remove(&expanded) {
+        println!("{} {}", "Not mounted:".yellow(), expanded);
+        return Ok(());
+    }
+    gc.save(config)?;
+    println!("{} {}", "Unmounted:".green().bold(), expanded);
+    Ok(())
+}
+
+pub fn run_list(config: &AppConfig) -> Result<()> {
+    let gc = GlobalConfig::load(config);
+    if gc.mounts.is_empty() {
+        println!(
+            "{}",
+            "No global mounts configured. Use `ai-pod mount add <host>[:<container>]`."
+                .dimmed()
+        );
+        return Ok(());
+    }
+    for m in &gc.mounts {
+        let target = crate::container::resolve_container_target(m, &config.home_dir)
+            .unwrap_or_else(|_| "(invalid)".to_string());
+        let mode = if m.writable { "rw" } else { "ro" };
+        let exists = if Path::new(&m.host).exists() {
+            ""
+        } else {
+            "  (missing — will be skipped at launch)"
+        };
+        println!("{:<50} → {:<40} [{}]{}", m.host, target, mode, exists);
+    }
+    Ok(())
+}
+
+/// One-line warning for `mount add` when the host file is mode-restricted in a
+/// way that the in-container `ai-pod` user is unlikely to be able to read it.
+/// Best-effort; silent on any error.
+fn warn_if_unreadable(spec: &MountSpec) -> Result<()> {
+    let path = Path::new(&spec.host);
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(_) => return Ok(()),
+    };
+    if !meta.is_file() {
+        return Ok(());
+    }
+    let mode = meta.permissions().mode() & 0o777;
+    if mode & 0o004 != 0 {
+        return Ok(());
+    }
+    eprintln!(
+        "{} {} has mode {:o}; the container user may not be able to read it under \
+         rootless podman. Consider `chmod o+r {}` or rely on docker / rootful podman.",
+        "warning:".yellow().bold(),
+        spec.host,
+        mode,
+        spec.host
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parse_spec_host_only() {
+        let dir = TempDir::new().unwrap();
+        let spec = parse_spec("/abs/path", false, dir.path()).unwrap();
+        assert_eq!(spec.host, "/abs/path");
+        assert_eq!(spec.container, None);
+        assert!(!spec.writable);
+    }
+
+    #[test]
+    fn parse_spec_host_and_container() {
+        let dir = TempDir::new().unwrap();
+        let spec = parse_spec("/abs/a:/abs/b", true, dir.path()).unwrap();
+        assert_eq!(spec.host, "/abs/a");
+        assert_eq!(spec.container.as_deref(), Some("/abs/b"));
+        assert!(spec.writable);
+    }
+
+    #[test]
+    fn parse_spec_expands_tilde_in_host() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let spec = parse_spec("~/.claude/skills", false, home).unwrap();
+        assert_eq!(spec.host, home.join(".claude/skills").display().to_string());
+    }
+
+    #[test]
+    fn parse_spec_rejects_relative_host() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("relative/path", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("absolute"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_traversal_in_host() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/a/../b", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains(".."));
+    }
+
+    #[test]
+    fn parse_spec_rejects_app_target() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/host:/app/foo", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("/app"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_app_root_target() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/host:/app", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("/app"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_reserved_target() {
+        let dir = TempDir::new().unwrap();
+        for r in ["/proc", "/proc/sys", "/sys", "/dev/null", "/etc/passwd"] {
+            let err = parse_spec(&format!("/host:{}", r), false, dir.path()).unwrap_err();
+            assert!(err.to_string().contains("reserved"), "target {} should be reserved", r);
+        }
+    }
+
+    #[test]
+    fn parse_spec_rejects_container_home_exactly() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/host:/home/ai-pod", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("home volume"));
+    }
+
+    #[test]
+    fn parse_spec_accepts_container_home_subpath() {
+        let dir = TempDir::new().unwrap();
+        let spec = parse_spec("/host:/home/ai-pod/.claude/skills", false, dir.path()).unwrap();
+        assert_eq!(spec.container.as_deref(), Some("/home/ai-pod/.claude/skills"));
+    }
+
+    #[test]
+    fn expand_tilde_only_at_start() {
+        let home = Path::new("/H");
+        assert_eq!(expand_tilde("~", home), "/H");
+        assert_eq!(expand_tilde("~/foo", home), "/H/foo");
+        assert_eq!(expand_tilde("/abs/~/foo", home), "/abs/~/foo");
+        assert_eq!(expand_tilde("/abs", home), "/abs");
+    }
+
+    #[test]
+    fn run_add_rejects_no_container_outside_home() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().to_path_buf();
+        let config_dir = home.join(".ai-pod");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config = AppConfig {
+            runtime_settings: config_dir.join("runtime-settings.json"),
+            config_dir,
+            home_dir: home,
+        };
+        let err = run_add(&config, "/etc/foo", false).unwrap_err();
+        assert!(err.to_string().contains("outside $HOME"));
+    }
+
+    #[test]
+    fn run_add_and_remove_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().to_path_buf();
+        let config_dir = home.join(".ai-pod");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config = AppConfig {
+            runtime_settings: config_dir.join("runtime-settings.json"),
+            config_dir,
+            home_dir: home.clone(),
+        };
+        std::fs::create_dir_all(home.join(".claude/skills")).unwrap();
+
+        run_add(&config, "~/.claude/skills", false).unwrap();
+        let gc = GlobalConfig::load(&config);
+        assert_eq!(gc.mounts.len(), 1);
+        assert_eq!(
+            gc.mounts[0].host,
+            home.join(".claude/skills").display().to_string()
+        );
+
+        run_remove(
+            &config,
+            &home.join(".claude/skills").display().to_string(),
+        )
+        .unwrap();
+        let gc = GlobalConfig::load(&config);
+        assert!(gc.mounts.is_empty());
+    }
+
+    #[test]
+    fn run_add_dedups_by_host() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().to_path_buf();
+        let config_dir = home.join(".ai-pod");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config = AppConfig {
+            runtime_settings: config_dir.join("runtime-settings.json"),
+            config_dir,
+            home_dir: home.clone(),
+        };
+        std::fs::create_dir_all(home.join(".claude/skills")).unwrap();
+
+        run_add(&config, "~/.claude/skills", false).unwrap();
+        run_add(&config, "~/.claude/skills", true).unwrap();
+        let gc = GlobalConfig::load(&config);
+        assert_eq!(gc.mounts.len(), 1, "duplicate host should not be added");
+        assert!(!gc.mounts[0].writable, "first add wins");
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -195,7 +195,9 @@ async fn reload_handler(State(state): State<AppState>) -> &'static str {
                 Some(s) => s.to_string(),
                 None => continue,
             };
-            if stem == "server" {
+            // "server" = the shared server state, "config" = the global
+            // GlobalConfig (mounts). Neither is a per-project state file.
+            if stem == "server" || stem == "config" {
                 continue;
             }
             let ps = ProjectState::load(&path);
@@ -226,7 +228,9 @@ pub async fn run_server(port: u16, config: AppConfig, rt: ContainerRuntime) -> a
                 Some(s) => s.to_string(),
                 None => continue,
             };
-            if stem == "server" {
+            // "server" = the shared server state, "config" = the global
+            // GlobalConfig (mounts). Neither is a per-project state file.
+            if stem == "server" || stem == "config" {
                 continue;
             }
             let state = ProjectState::load(&path);


### PR DESCRIPTION
Closes #91.

## Summary

- New `~/.ai-pod/config.json` (global, 0o600) holding a `mounts` list applied to every container launch.
- New `ai-pod mount add|remove|list` subcommand. Spec is `host[:container]`. When `container` is omitted, the host path must be under `$HOME` and gets mirrored under `/home/ai-pod`.
- Default mount mode is **read-only** (`:z,ro`); opt in with `--writable`. Uses the `:z` SELinux label (shared) so the host user retains access to e.g. `~/.claude/skills` after the container touches it.
- Mount order in `podman run`: home volume → workspace → user mounts → mask volumes. User mounts under `/app` are forbidden (would silently shadow the workspace bind); `/proc`, `/sys`, `/dev`, `/etc`, `/tmp`, `/run`, `/var/run` and exact `/home/ai-pod` are also rejected.
- Missing host paths warn at launch and are skipped, so a temporarily-absent host directory doesn't brick every project.

## Example

```
$ ai-pod mount add ~/.claude/skills
Mounted: /home/user/.claude/skills → /home/ai-pod/.claude/skills (ro)

$ ai-pod mount add ~/.secrets/gh.pem --writable
Mounted: /home/user/.secrets/gh.pem → /home/ai-pod/.secrets/gh.pem (rw)

$ ai-pod mount list
/home/user/.claude/skills    → /home/ai-pod/.claude/skills    [ro]
/home/user/.secrets/gh.pem   → /home/ai-pod/.secrets/gh.pem   [rw]

$ ai-pod mount remove ~/.secrets/gh.pem
Unmounted: /home/user/.secrets/gh.pem
```

## Out of scope (deferred)

- Copying files into the home volume on init (the other half of #91 — "stuff in $HOME").
- Per-workspace overrides of the global mount list.
- Interactive TUI for `ai-pod mount` with no sub-action.
- Auto-`chmod` / `:U` handling for uid-mismatched files. (A warning is emitted at `mount add` when a host file is mode-restricted.)

## Test plan

- [x] Unit: `GlobalConfig` round-trip, malformed-file fallback, 0o600 perms, dedup
- [x] Unit: spec parser (host-only, host:container, tilde expansion, traversal/relative/`/app`/reserved rejection)
- [x] Unit: `build_mount_args` emits `:z` vs `:z,ro`, mirrors home paths, skips missing sources
- [x] Unit: `run_add` rejects `/etc/foo` without explicit container; `run_add`/`run_remove` round-trip
- [x] `cargo build` + `cargo test` (139/139 passing in lib, 5/5 in bin)
- [x] Manual smoke: add / list / dedup / outside-home rejection / `/app` rejection / reserved rejection / remove
- [ ] End-to-end: launch a container with a mount and confirm the host path is visible at the expected target

https://claude.ai/code/session_017mSEVvWtrHcaSNhj4DbZq9

---
_Generated by [Claude Code](https://claude.ai/code/session_017mSEVvWtrHcaSNhj4DbZq9)_