### PR TITLE
feat: service containers via MCP (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,32 @@ The in-container agent talks to the host through an **MCP server** running on th
 | `list_commands` | List commands for this session (or workspace-wide with `scope=workspace`). |
 | `notify_user` | Send a desktop notification to the host user. |
 | `list_allowed_commands` | List host commands previously approved by the user for this workspace. |
+| `start_service` | Start an auxiliary service container (e.g. `postgres:16`) reachable from inside the agent container. |
+| `stop_service` | Stop and remove a service container started by this session. |
+| `list_services` | List service containers started by this session. |
+| `service_logs` | Read the tail of a service container's logs. |
+
+### Service containers
+
+The agent can spin up auxiliary containers (postgres, redis, …) it needs
+for the task at hand by calling the `start_service` MCP tool. Each
+request specifies an image, a short `name`, optional env vars, and
+optional command override. The host user approves the image plus the
+**sorted list of env-var KEY names** (values stay private and never
+enter the on-disk allowlist); re-requesting the same image with the
+same set of keys is auto-approved.
+
+Service containers live on a per-workspace bridge network
+(`ai-pod-<workspace-hash>-net`). The agent reaches a service by the
+`name` it requested, on the service's standard port — e.g. asking for
+`name=postgres image=postgres:16` makes it reachable from the agent
+container as `postgres:5432`. No host port mapping is created.
+
+Services are **ephemeral**. A fresh anonymous volume is allocated each
+session and discarded when the session ends; the service container
+itself is removed as soon as the main ai-pod container exits (or, as a
+backstop, by a periodic sweep in the shared server). `ai-pod clean`
+also removes the per-workspace network.
 
 ### Command output files
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ ai-pod --workdir /path/to/project
 | `clean [--workdir PATH]` | Stop and remove the container for a workspace |
 | `run <command> [args...]` | Run a command in the container instead of the default |
 | `commands [list\|run\|kill\|logs]` | View/manage host commands (interactive TUI if no subcommand) |
+| `services [list\|logs\|stop]` | View/manage service containers started by agents (interactive TUI if no subcommand) |
 | `allowed [list\|add\|remove]` | Manage the always-allowed command whitelist (interactive TUI if no subcommand) |
 | `mask <dir> [--workdir PATH]` | Shadow-mount `/app/<dir>` with an isolated per-workspace volume |
 | `unmask <dir> [--workdir PATH]` | Stop masking `<dir>` and delete its shadow volume |
@@ -184,6 +185,18 @@ session and discarded when the session ends; the service container
 itself is removed as soon as the main ai-pod container exits (or, as a
 backstop, by a periodic sweep in the shared server). `ai-pod clean`
 also removes the per-workspace network.
+
+#### Inspecting services from the host
+
+```sh
+ai-pod services                          # interactive TUI
+ai-pod services list                     # plain list across all sessions
+ai-pod services logs <name> [--lines N]  # tail logs of a service
+ai-pod services stop <name>              # stop a running service
+```
+
+The `--session <id>` flag disambiguates when the same name is in use
+across concurrent sessions on the same workspace.
 
 ### Command output files
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,6 +95,13 @@ pub enum Command {
         action: Option<CommandsAction>,
     },
 
+    /// View and manage service containers (postgres, redis, etc.) started by
+    /// agents in the current workspace. Run with no subcommand for a TUI.
+    Services {
+        #[command(subcommand)]
+        action: Option<ServicesAction>,
+    },
+
     /// Manage the whitelist of always-allowed commands for a workspace.
     /// Run with no subcommand to open an interactive TUI.
     Allowed {
@@ -161,6 +168,29 @@ pub enum CommandsAction {
     /// Print stdout/stderr/exit for a command
     Logs {
         command_id: String,
+        #[arg(long)]
+        session: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ServicesAction {
+    /// Plain list (one row per service)
+    List,
+    /// Print recent log output for a service
+    Logs {
+        name: String,
+        /// Session id (optional; resolved from the workspace if exactly one session owns the name)
+        #[arg(long)]
+        session: Option<String>,
+        /// Number of trailing log lines to print
+        #[arg(long, default_value_t = 50)]
+        lines: usize,
+    },
+    /// Stop and remove a service container
+    Stop {
+        name: String,
+        /// Session id (optional; resolved from the workspace if exactly one session owns the name)
         #[arg(long)]
         session: Option<String>,
     },

--- a/src/container.rs
+++ b/src/container.rs
@@ -618,6 +618,14 @@ pub fn launch_container(
     let project_state = load_project_state(config, workspace);
     let mask_args = mask_mount_args(rt, workspace, image, &project_state.masked_directories)?;
 
+    // Create the per-workspace service network up front and attach the main
+    // container to it at launch. Lazy attach via `podman network connect` after
+    // the fact does not work for rootless podman (slirp4netns containers cannot
+    // be added to additional networks), so any later `start_service` call would
+    // fail. Doing it here makes service-container requests work on every
+    // runtime without restarting the session.
+    let service_net = crate::service::ensure_service_network(rt, workspace)?;
+
     let mut run_cmd = rt.command();
     run_cmd.args(["run", "--rm", "-it"]);
     run_cmd.args([
@@ -625,6 +633,8 @@ pub fn launch_container(
         &container_name,
         "--label",
         "managed-by=ai-pod",
+        "--network",
+        &service_net,
         "-v",
         &format!("{}:{}:z", volume_name, CONTAINER_HOME),
         "-v",
@@ -714,6 +724,11 @@ pub fn run_in_container(
     let project_state = load_project_state(config, workspace);
     let mask_args = mask_mount_args(rt, workspace, image, &project_state.masked_directories)?;
 
+    // See the matching comment in launch_container — main goes on the
+    // per-workspace service network at launch so service containers can be
+    // attached later on rootless podman.
+    let service_net = crate::service::ensure_service_network(rt, workspace)?;
+
     let mut run_args: Vec<String> = vec![
         "run".into(),
         "--rm".into(),
@@ -722,6 +737,8 @@ pub fn run_in_container(
     run_args.extend_from_slice(&[
         "--label".into(),
         "managed-by=ai-pod".into(),
+        "--network".into(),
+        service_net,
         "-v".into(),
         format!("{}:{}:z", volume_name, CONTAINER_HOME),
         "-v".into(),

--- a/src/container.rs
+++ b/src/container.rs
@@ -649,12 +649,18 @@ pub fn launch_container(
         &opencode_config_env,
     ]);
     run_cmd.arg(image);
-    run_cmd
+    let run_status = run_cmd
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()
         .context("Failed to run container")?;
+
+    // Main container has exited (cleanly or otherwise); tear down anything the
+    // agent started for this session. Best-effort: this is also covered by the
+    // server's periodic orphan sweep if the CLI was killed.
+    crate::service::cleanup_services_for_session(rt, &session_id);
+    let _ = run_status;
 
     Ok(())
 }
@@ -753,6 +759,8 @@ pub fn run_in_container(
         .stderr(Stdio::inherit())
         .status()
         .context("Failed to run command in container")?;
+
+    crate::service::cleanup_services_for_session(rt, &session_id);
 
     if !status.success() {
         anyhow::bail!("Command exited with non-zero status");
@@ -885,6 +893,9 @@ pub fn clean_container(
     for dir in &state.masked_directories {
         let _ = remove_mask_volume(rt, workspace, dir);
     }
+
+    // Remove the per-workspace service-container network if it exists.
+    crate::service::remove_service_network(rt, workspace);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,6 @@ pub mod image;
 pub mod runtime;
 pub mod server;
 pub mod service;
+pub mod services_cli;
 pub mod update;
 pub mod workspace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ pub mod env_files_cli;
 pub mod image;
 pub mod runtime;
 pub mod server;
+pub mod service;
 pub mod update;
 pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use ai_pod::{
     cli, commands_cli, config, container, credentials, env_files_cli, image, runtime, server,
-    update, workspace,
+    services_cli, update, workspace,
 };
 
 use anyhow::{Context, Result};
@@ -8,7 +8,7 @@ use clap::Parser;
 use colored::Colorize;
 use std::path::Path;
 
-use cli::{AllowedAction, Cli, Command, CommandsAction, EnvFilesAction};
+use cli::{AllowedAction, Cli, Command, CommandsAction, EnvFilesAction, ServicesAction};
 use config::AppConfig;
 use runtime::ContainerRuntime;
 
@@ -535,6 +535,19 @@ async fn main() -> Result<()> {
                 Some(CommandsAction::Logs { command_id, session }) => {
                     commands_cli::run_logs(&config, &workspace, session.as_deref(), command_id)
                         .await?;
+                }
+            }
+        }
+        Some(Command::Services { action }) => {
+            let workspace = resolve_workspace(&cli.workdir)?;
+            match action {
+                None => services_cli::run_tui(&rt, &workspace)?,
+                Some(ServicesAction::List) => services_cli::run_list(&rt, &workspace)?,
+                Some(ServicesAction::Logs { name, session, lines }) => {
+                    services_cli::run_logs(&rt, &workspace, name, session.as_deref(), *lines)?;
+                }
+                Some(ServicesAction::Stop { name, session }) => {
+                    services_cli::run_stop(&rt, &workspace, name, session.as_deref())?;
                 }
             }
         }

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -49,17 +49,42 @@ pub async fn request_approval(
     command: &str,
     project_name: &str,
 ) -> ApprovalDecision {
+    request_approval_with_body(
+        state,
+        format!("Run command:\n{}", command),
+        // macOS dialog needs the literal command string as a script arg.
+        command,
+        project_name,
+    )
+    .await
+}
+
+/// Show the approval dialog for an arbitrary action.
+///
+/// `body` is the multi-line message shown to the user on Linux. `subject` is
+/// the raw item being approved (used as the AppleScript argument on macOS so
+/// the script can render whatever wording it wants). `project_name` titles the
+/// dialog. All three are passed through the existing `approval_lock` so two
+/// approval prompts can't appear at once.
+async fn request_approval_with_body(
+    state: &AppState,
+    body: String,
+    subject: &str,
+    project_name: &str,
+) -> ApprovalDecision {
     let _guard = state.approval_lock.lock().await;
-    let command = command.to_string();
+    let body = body;
+    let subject = subject.to_string();
     let project_name = project_name.to_string();
 
     tokio::task::spawn_blocking(move || {
         #[cfg(target_os = "linux")]
         {
+            let _ = &subject; // unused on linux; macOS branch consumes it
             let mut decision = ApprovalDecision::PermissionTimeout;
             let result = notify_rust::Notification::new()
                 .summary(&format!("ai-pod: {}", project_name))
-                .body(&format!("Run command:\n{}", command))
+                .body(&body)
                 .action("allow_once", "Allow Once")
                 .action("always_allow", "Always Allow")
                 .action("deny", "Deny")
@@ -80,9 +105,10 @@ pub async fn request_approval(
         }
         #[cfg(target_os = "macos")]
         {
+            let _ = &body; // body is rendered by the AppleScript itself
             let (tx, rx) = std::sync::mpsc::channel();
             std::thread::spawn(move || {
-                let output = build_approval_command(&command, &project_name).output();
+                let output = build_approval_command(&subject, &project_name).output();
                 let _ = tx.send(output);
             });
             match rx.recv_timeout(std::time::Duration::from_secs(60)) {
@@ -102,6 +128,7 @@ pub async fn request_approval(
         }
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
+            let _ = (&body, &subject);
             ApprovalDecision::Deny
         }
     })
@@ -173,6 +200,55 @@ pub fn get_allowed_commands(state: &AppState, workspace: &Path) -> Vec<String> {
     let state_file = state.config_dir.join(format!("{}.json", hash));
     let project_state = ProjectState::load(&state_file);
     project_state.allowed_commands
+}
+
+/// Canonical string that identifies a `start_service` request for approval
+/// purposes. Only the env-var KEY names are included (sorted), so secret
+/// values never enter the on-disk allowlist.
+pub fn service_approval_key(image: &str, env_keys: &[String]) -> String {
+    if env_keys.is_empty() {
+        return image.to_string();
+    }
+    let mut keys = env_keys.to_vec();
+    keys.sort();
+    keys.dedup();
+    format!("{} with env [{}]", image, keys.join(", "))
+}
+
+/// Approve (or pre-approve) a service-container start request. Mirrors
+/// `run_host_command` but consults `allowed_services` instead of
+/// `allowed_commands` and prompts with a service-flavoured message.
+pub async fn run_service_request(
+    state: &AppState,
+    image: &str,
+    env_keys: &[String],
+    workspace: &Path,
+) -> ApprovalOutcome {
+    let key = service_approval_key(image, env_keys);
+    let hash = workspace_hash(workspace);
+    let state_file = state.config_dir.join(format!("{}.json", hash));
+    let ps = ProjectState::load(&state_file);
+    if ps.is_service_allowed(&key) {
+        return ApprovalOutcome::Approved;
+    }
+
+    let project_name = workspace
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let body = format!("Start service container:\n{}", key);
+    match request_approval_with_body(state, body, &key, &project_name).await {
+        ApprovalDecision::AllowOnce => ApprovalOutcome::Approved,
+        ApprovalDecision::AlwaysAllow => {
+            let mut ps = ProjectState::load(&state_file);
+            ps.add_allowed_service(&key);
+            let _ = ps.save(&state_file);
+            ApprovalOutcome::AlwaysAllow
+        }
+        ApprovalDecision::Deny => ApprovalOutcome::Denied,
+        ApprovalDecision::PermissionTimeout => ApprovalOutcome::Timeout,
+    }
 }
 
 #[cfg(test)]
@@ -281,5 +357,40 @@ mod tests {
         assert!(!check_command_rejected("ls | headroom"));
         assert!(!check_command_rejected("ls | tailored"));
         assert!(!check_command_rejected("ls | heading"));
+    }
+
+    #[test]
+    fn service_approval_key_drops_env_when_empty() {
+        assert_eq!(service_approval_key("postgres:16", &[]), "postgres:16");
+    }
+
+    #[test]
+    fn service_approval_key_sorts_env_keys() {
+        let unsorted = vec!["POSTGRES_USER".to_string(), "POSTGRES_DB".to_string()];
+        let sorted = vec!["POSTGRES_DB".to_string(), "POSTGRES_USER".to_string()];
+        assert_eq!(
+            service_approval_key("postgres:16", &unsorted),
+            service_approval_key("postgres:16", &sorted),
+        );
+        assert_eq!(
+            service_approval_key("postgres:16", &sorted),
+            "postgres:16 with env [POSTGRES_DB, POSTGRES_USER]",
+        );
+    }
+
+    #[test]
+    fn service_approval_key_dedupes_env_keys() {
+        let dupes = vec!["A".to_string(), "A".to_string(), "B".to_string()];
+        assert_eq!(
+            service_approval_key("img", &dupes),
+            "img with env [A, B]",
+        );
+    }
+
+    #[test]
+    fn service_approval_key_differs_when_keys_differ() {
+        let a = service_approval_key("postgres:16", &["A".to_string()]);
+        let b = service_approval_key("postgres:16", &["B".to_string()]);
+        assert_ne!(a, b);
     }
 }

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -38,6 +38,10 @@ pub struct ProjectState {
     pub ignored_credential_files: Vec<String>,
     #[serde(default)]
     pub masked_directories: Vec<String>,
+    /// Canonical "image with env [KEYS]" strings the user has approved for
+    /// `start_service` requests. See `commands::service_approval_key`.
+    #[serde(default)]
+    pub allowed_services: Vec<String>,
 }
 
 impl ProjectState {
@@ -106,6 +110,16 @@ impl ProjectState {
 
     pub fn remove_masked(&mut self, dir: &str) {
         self.masked_directories.retain(|d| d != dir);
+    }
+
+    pub fn is_service_allowed(&self, key: &str) -> bool {
+        self.allowed_services.iter().any(|k| k == key)
+    }
+
+    pub fn add_allowed_service(&mut self, key: &str) {
+        if !self.is_service_allowed(key) {
+            self.allowed_services.push(key.to_string());
+        }
     }
 }
 
@@ -361,6 +375,7 @@ mod tests {
             api_key: "secret".into(),
             ignored_credential_files: vec![],
             masked_directories: vec![],
+            allowed_services: vec![],
         };
         state.save(&path).unwrap();
         let perms = std::fs::metadata(&path).unwrap().permissions();
@@ -395,6 +410,7 @@ mod tests {
             api_key: "deadbeef1234567890abcdef12345678".into(),
             ignored_credential_files: vec![],
             masked_directories: vec![],
+            allowed_services: vec![],
         };
         state.save(&path).unwrap();
         let loaded = ProjectState::load(&path);
@@ -425,6 +441,39 @@ mod tests {
         state.add_allowed("npm test");
         state.add_allowed("npm test");
         assert_eq!(state.allowed_commands.len(), 1);
+    }
+
+    #[test]
+    fn service_helpers_round_trip() {
+        let mut state = ProjectState::default();
+        assert!(!state.is_service_allowed("postgres:16"));
+        state.add_allowed_service("postgres:16");
+        state.add_allowed_service("postgres:16");
+        state.add_allowed_service("redis:7");
+        assert!(state.is_service_allowed("postgres:16"));
+        assert!(state.is_service_allowed("redis:7"));
+        assert_eq!(state.allowed_services.len(), 2);
+    }
+
+    #[test]
+    fn allowed_services_default_loads_when_field_missing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("legacy.json");
+        // Simulate a state file written by an older version (no allowed_services).
+        std::fs::write(
+            &path,
+            r#"{
+              "workspace": "/home/user/proj",
+              "allowed_commands": [],
+              "api_key": "abc",
+              "ignored_credential_files": [],
+              "masked_directories": []
+            }"#,
+        )
+        .unwrap();
+        let loaded = ProjectState::load(&path);
+        assert_eq!(loaded.workspace, "/home/user/proj");
+        assert!(loaded.allowed_services.is_empty());
     }
 
     #[test]

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -21,6 +21,8 @@ use super::commands;
 use super::notify;
 use super::runner;
 use crate::runtime::ContainerRuntime;
+use crate::service;
+use crate::workspace::validate_service_name;
 
 const PROTOCOL_VERSION: &str = "2025-06-18";
 
@@ -120,6 +122,54 @@ fn tools_definition(runtime: &ContainerRuntime) -> Value {
             "name": "list_allowed_commands",
             "description": "List host commands previously approved by the user for this workspace.",
             "inputSchema": { "type": "object" }
+        },
+        {
+            "name": "start_service",
+            "description": "Start an auxiliary service container (e.g. `postgres:16`) on a per-workspace bridge network. The user must approve the image + env-var KEY set once per workspace. Reach the service from this container by the `name` you pass, on the service's standard port — e.g. `name=\"postgres\"` → `postgres:5432`. No host port mapping is created. The service is ephemeral: data lives only for this ai-pod session and is discarded when the session ends. Returns `{ host, container_name }`.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "image": { "type": "string", "description": "Container image, e.g. `postgres:16`." },
+                    "name": { "type": "string", "description": "DNS alias used to reach the service from this container. Lowercase [a-z0-9-], 1-30 chars, starts with alphanumeric." },
+                    "env": {
+                        "type": "object",
+                        "description": "Environment variables for the container. Values are passed through unchanged; only the sorted KEY list is shown to the user during approval.",
+                        "additionalProperties": { "type": "string" }
+                    },
+                    "command": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional command override for the image."
+                    }
+                },
+                "required": ["image", "name"]
+            }
+        },
+        {
+            "name": "stop_service",
+            "description": "Stop and remove a service container started by this session. No-op if the name doesn't match a service this session owns.",
+            "inputSchema": {
+                "type": "object",
+                "properties": { "name": { "type": "string" } },
+                "required": ["name"]
+            }
+        },
+        {
+            "name": "list_services",
+            "description": "List service containers started by this session in this workspace.",
+            "inputSchema": { "type": "object" }
+        },
+        {
+            "name": "service_logs",
+            "description": "Read the tail of a service container's logs (stdout+stderr). Useful when a service fails to start.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "lines": { "type": "integer", "description": "Number of trailing lines to return (default 50)." }
+                },
+                "required": ["name"]
+            }
         }
     ])
 }
@@ -188,6 +238,187 @@ pub async fn mcp_handler(
     }
 }
 
+async fn handle_start_service(
+    state: &AppState,
+    workspace: &std::path::Path,
+    session_id: &str,
+    args: &Value,
+) -> Value {
+    let image = match args.get("image").and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => return tool_error("Missing `image`".into()),
+    };
+    let name = match args.get("name").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => return tool_error("Missing `name`".into()),
+    };
+    if let Err(e) = validate_service_name(name) {
+        return tool_error(e);
+    }
+    let name = name.to_string();
+
+    let env_pairs: Vec<(String, String)> = match args.get("env") {
+        Some(Value::Null) | None => Vec::new(),
+        Some(Value::Object(map)) => {
+            let mut out = Vec::with_capacity(map.len());
+            for (k, v) in map {
+                let val = match v {
+                    Value::String(s) => s.clone(),
+                    Value::Number(n) => n.to_string(),
+                    Value::Bool(b) => b.to_string(),
+                    _ => {
+                        return tool_error(format!(
+                            "env value for `{}` must be a string, number, or boolean",
+                            k
+                        ));
+                    }
+                };
+                out.push((k.clone(), val));
+            }
+            out
+        }
+        _ => return tool_error("`env` must be an object".into()),
+    };
+    let env_keys: Vec<String> = env_pairs.iter().map(|(k, _)| k.clone()).collect();
+
+    let command: Vec<String> = match args.get("command") {
+        Some(Value::Null) | None => Vec::new(),
+        Some(Value::Array(items)) => {
+            let mut out = Vec::with_capacity(items.len());
+            for it in items {
+                match it.as_str() {
+                    Some(s) => out.push(s.to_string()),
+                    None => return tool_error("`command` entries must be strings".into()),
+                }
+            }
+            out
+        }
+        _ => return tool_error("`command` must be an array of strings".into()),
+    };
+
+    match commands::run_service_request(state, &image, &env_keys, workspace).await {
+        commands::ApprovalOutcome::Denied => return tool_error("Service start denied by user".into()),
+        commands::ApprovalOutcome::Timeout => {
+            return tool_error("Permission request timed out after 60 seconds.".into());
+        }
+        commands::ApprovalOutcome::Rejected => {
+            return tool_error("Service start rejected".into());
+        }
+        commands::ApprovalOutcome::Approved | commands::ApprovalOutcome::AlwaysAllow => {}
+    }
+
+    let rt = state.runtime.clone();
+    let workspace_owned = workspace.to_path_buf();
+    let session_owned = session_id.to_string();
+    let join = tokio::task::spawn_blocking(move || {
+        service::start_service(
+            &rt,
+            &workspace_owned,
+            &session_owned,
+            &image,
+            &name,
+            &env_pairs,
+            &command,
+        )
+    })
+    .await;
+    match join {
+        Err(_) => tool_error("internal error spawning service".into()),
+        Ok(Err(e)) => tool_error(format!("Failed to start service: {e}")),
+        Ok(Ok(started)) => json!({
+            "content": [{
+                "type": "text",
+                "text": serde_json::to_string_pretty(&started).unwrap_or_default()
+            }],
+            "isError": false,
+            "structuredContent": started,
+        }),
+    }
+}
+
+async fn handle_stop_service(
+    state: &AppState,
+    workspace: &std::path::Path,
+    session_id: &str,
+    args: &Value,
+) -> Value {
+    let name = match args.get("name").and_then(|v| v.as_str()) {
+        Some(s) => s.to_string(),
+        None => return tool_error("Missing `name`".into()),
+    };
+    let rt = state.runtime.clone();
+    let workspace_owned = workspace.to_path_buf();
+    let session_owned = session_id.to_string();
+    let join = tokio::task::spawn_blocking(move || {
+        service::stop_service(&rt, &workspace_owned, &session_owned, &name)
+    })
+    .await;
+    match join {
+        Err(_) => tool_error("internal error stopping service".into()),
+        Ok(Err(e)) => tool_error(format!("Failed to stop service: {e}")),
+        Ok(Ok(stopped)) => json!({
+            "content": [{ "type": "text", "text": format!("stopped: {stopped}") }],
+            "isError": false,
+            "structuredContent": { "stopped": stopped },
+        }),
+    }
+}
+
+async fn handle_list_services(
+    state: &AppState,
+    workspace: &std::path::Path,
+    session_id: &str,
+) -> Value {
+    let rt = state.runtime.clone();
+    let workspace_owned = workspace.to_path_buf();
+    let session_owned = session_id.to_string();
+    let join = tokio::task::spawn_blocking(move || {
+        service::list_services(&rt, &workspace_owned, &session_owned)
+    })
+    .await;
+    match join {
+        Err(_) => tool_error("internal error listing services".into()),
+        Ok(Err(e)) => tool_error(format!("Failed to list services: {e}")),
+        Ok(Ok(list)) => json!({
+            "content": [{
+                "type": "text",
+                "text": serde_json::to_string_pretty(&list).unwrap_or_default()
+            }],
+            "isError": false,
+            "structuredContent": { "services": list },
+        }),
+    }
+}
+
+async fn handle_service_logs(
+    state: &AppState,
+    workspace: &std::path::Path,
+    session_id: &str,
+    args: &Value,
+) -> Value {
+    let name = match args.get("name").and_then(|v| v.as_str()) {
+        Some(s) => s.to_string(),
+        None => return tool_error("Missing `name`".into()),
+    };
+    let lines = args
+        .get("lines")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)
+        .unwrap_or(50);
+    let rt = state.runtime.clone();
+    let workspace_owned = workspace.to_path_buf();
+    let session_owned = session_id.to_string();
+    let join = tokio::task::spawn_blocking(move || {
+        service::service_logs(&rt, &workspace_owned, &session_owned, &name, lines)
+    })
+    .await;
+    match join {
+        Err(_) => tool_error("internal error reading service logs".into()),
+        Ok(Err(e)) => tool_error(format!("Failed to read service logs: {e}")),
+        Ok(Ok(text)) => tool_text(text),
+    }
+}
+
 async fn resolve_project_id(state: &AppState, api_key: &str) -> Option<String> {
     let map = state.projects.lock().await;
     for (pid, info) in map.iter() {
@@ -252,6 +483,42 @@ mod tests {
         assert!(
             desc.contains("Read tool"),
             "description should tell the agent to use its Read tool, got: {desc}"
+        );
+    }
+
+    #[test]
+    fn tools_definition_includes_service_tools() {
+        let v = tools_definition(&test_runtime(RuntimeKind::Podman));
+        let names: Vec<&str> = v
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"start_service"));
+        assert!(names.contains(&"stop_service"));
+        assert!(names.contains(&"list_services"));
+        assert!(names.contains(&"service_logs"));
+    }
+
+    #[test]
+    fn start_service_description_mentions_lifetime_and_reachability() {
+        let v = tools_definition(&test_runtime(RuntimeKind::Podman));
+        let desc = v
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|t| t["name"] == "start_service")
+            .unwrap()["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            desc.contains("session"),
+            "start_service description should mention per-session lifetime, got: {desc}"
+        );
+        assert!(
+            desc.contains("postgres:5432") || desc.to_lowercase().contains("standard port"),
+            "start_service description should explain DNS-name reachability, got: {desc}"
         );
     }
 
@@ -395,6 +662,10 @@ async fn handle_tool_call(
                 "structuredContent": { "commands": cmds },
             })
         }
+        "start_service" => handle_start_service(state, workspace, session_id, &args).await,
+        "stop_service" => handle_stop_service(state, workspace, session_id, &args).await,
+        "list_services" => handle_list_services(state, workspace, session_id).await,
+        "service_logs" => handle_service_logs(state, workspace, session_id, &args).await,
         other => tool_error(format!("Unknown tool: {other}")),
     }
 }

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -346,6 +346,9 @@ async fn handle_stop_service(
         Some(s) => s.to_string(),
         None => return tool_error("Missing `name`".into()),
     };
+    if let Err(e) = validate_service_name(&name) {
+        return tool_error(e);
+    }
     let rt = state.runtime.clone();
     let workspace_owned = workspace.to_path_buf();
     let session_owned = session_id.to_string();
@@ -400,6 +403,9 @@ async fn handle_service_logs(
         Some(s) => s.to_string(),
         None => return tool_error("Missing `name`".into()),
     };
+    if let Err(e) = validate_service_name(&name) {
+        return tool_error(e);
+    }
     let lines = args
         .get("lines")
         .and_then(|v| v.as_u64())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -183,6 +183,82 @@ pub fn build_app(state: AppState) -> Router {
         .with_state(state)
 }
 
+/// Find live `ai-pod-parent={session_id}` labels whose corresponding main
+/// container is no longer running and remove the service containers tied to
+/// them.
+async fn sweep_orphan_services(rt: &ContainerRuntime) {
+    // Set of session ids currently backed by a live main container.
+    let main_output = rt
+        .async_command()
+        .args([
+            "ps",
+            "--filter",
+            "label=managed-by=ai-pod",
+            "--format",
+            "{{.Names}}\t{{.Labels}}",
+        ])
+        .output()
+        .await;
+    let mut live_sessions: std::collections::HashSet<String> = std::collections::HashSet::new();
+    if let Ok(o) = main_output {
+        for line in String::from_utf8_lossy(&o.stdout).lines() {
+            let mut parts = line.splitn(2, '\t');
+            let name = parts.next().unwrap_or("");
+            let labels = parts.next().unwrap_or("");
+            // Skip containers that are themselves services — their parent label
+            // makes them ineligible to be a "main" container.
+            if labels.contains("ai-pod-service=true") {
+                continue;
+            }
+            if let Some(sid) = crate::workspace::session_id_from_container_name(name) {
+                live_sessions.insert(sid);
+            }
+        }
+    }
+
+    // List services and reap any whose parent session isn't live.
+    let services = rt
+        .async_command()
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "label=ai-pod-service=true",
+            "--format",
+            "{{.Names}}\t{{.Labels}}",
+        ])
+        .output()
+        .await;
+    let services = match services {
+        Ok(o) => o.stdout,
+        Err(_) => return,
+    };
+    for line in String::from_utf8_lossy(&services).lines() {
+        let mut parts = line.splitn(2, '\t');
+        let name = parts.next().unwrap_or("");
+        let labels = parts.next().unwrap_or("");
+        if name.is_empty() {
+            continue;
+        }
+        // Labels come back comma-separated as `k=v,k=v`. Find ai-pod-parent.
+        let parent = labels
+            .split(',')
+            .find_map(|kv| kv.trim().strip_prefix("ai-pod-parent="))
+            .map(|s| s.to_string());
+        let Some(parent) = parent else { continue };
+        if live_sessions.contains(&parent) {
+            continue;
+        }
+        let _ = rt
+            .async_command()
+            .args(["rm", "--force", name])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await;
+    }
+}
+
 async fn reload_handler(State(state): State<AppState>) -> &'static str {
     let mut projects = state.projects.lock().await;
     if let Ok(entries) = std::fs::read_dir(&state.config_dir) {
@@ -258,6 +334,13 @@ pub async fn run_server(port: u16, config: AppConfig, rt: ContainerRuntime) -> a
         let mut interval = tokio::time::interval(Duration::from_secs(60));
         loop {
             interval.tick().await;
+
+            // Sweep services whose parent session is no longer running. This
+            // is the backstop for the CLI's in-line cleanup: if `ai-pod` was
+            // SIGKILL'd before reaching that branch, the orphaned service
+            // containers would otherwise linger until `ai-pod clean`.
+            sweep_orphan_services(&shutdown_rt).await;
+
             if Instant::now() < *shutdown_keep_alive.lock().await {
                 continue;
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -186,6 +186,11 @@ pub fn build_app(state: AppState) -> Router {
 /// Find live `ai-pod-parent={session_id}` labels whose corresponding main
 /// container is no longer running and remove the service containers tied to
 /// them.
+///
+/// Label format note: `ps --format "{{.Labels}}"` emits `k=v,k=v` (equals
+/// inside, commas between entries). This is distinct from `inspect --format
+/// "{{.Config.Labels}}"`, which uses Go's `map[k:v]` rendering with colons —
+/// don't reuse this parser for inspect output.
 async fn sweep_orphan_services(rt: &ContainerRuntime) {
     // Set of session ids currently backed by a live main container.
     let main_output = rt

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,427 @@
+//! Service container management.
+//!
+//! "Service" containers are auxiliary containers (e.g. postgres) requested by
+//! the in-container agent via MCP. They live on a per-workspace bridge network
+//! so the agent reaches them by DNS name, are labeled with the requesting
+//! session's id for garbage collection, and are removed when that session
+//! exits.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::runtime::ContainerRuntime;
+use crate::workspace::{service_container_name, service_network_name};
+
+/// Label applied to every service container so we can list/clean them
+/// independently of the main container.
+pub const SERVICE_LABEL: &str = "ai-pod-service=true";
+/// Label key carrying the requesting session id.
+pub const PARENT_LABEL_KEY: &str = "ai-pod-parent";
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct ServiceInfo {
+    pub name: String,
+    pub container_name: String,
+    pub image: String,
+    pub status: String,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct StartedService {
+    pub host: String,
+    pub container_name: String,
+}
+
+/// Idempotently create the per-workspace network. Returns its name.
+pub fn ensure_service_network(rt: &ContainerRuntime, workspace: &std::path::Path) -> Result<String> {
+    let net = service_network_name(workspace);
+    let status = rt
+        .command()
+        .args(["network", "inspect", &net])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .context("failed to inspect network")?;
+    if status.success() {
+        return Ok(net);
+    }
+    let create = rt
+        .command()
+        .args(["network", "create", &net])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .context("failed to create network")?;
+    if !create.success() {
+        anyhow::bail!("failed to create service network {}", net);
+    }
+    Ok(net)
+}
+
+/// Find the running main container for `(workspace, session_id)`. Returns the
+/// container name. Errors if no such container is running.
+pub fn find_main_container(
+    rt: &ContainerRuntime,
+    workspace: &std::path::Path,
+    session_id: &str,
+) -> Result<String> {
+    let expected = crate::workspace::container_name_for(workspace, session_id);
+    let output = rt
+        .command()
+        .args([
+            "ps",
+            "--filter",
+            &format!("name=^{}$", expected),
+            "--filter",
+            "label=managed-by=ai-pod",
+            "--format",
+            "{{.Names}}",
+        ])
+        .output()
+        .context("failed to list main container")?;
+    let name = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find(|l| !l.is_empty())
+        .map(|l| l.to_string());
+    match name {
+        Some(n) => Ok(n),
+        None => anyhow::bail!(
+            "no running main container for session {} (expected {})",
+            session_id,
+            expected
+        ),
+    }
+}
+
+/// Attach the main container to the workspace network. Idempotent: a second
+/// call swallows the "already attached" error.
+pub fn connect_main_to_network(
+    rt: &ContainerRuntime,
+    workspace: &std::path::Path,
+    session_id: &str,
+) -> Result<()> {
+    let net = service_network_name(workspace);
+    let main = find_main_container(rt, workspace, session_id)?;
+    let output = rt
+        .command()
+        .args(["network", "connect", &net, &main])
+        .output()
+        .context("failed to connect main container to service network")?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    if stderr.contains("already") {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "failed to connect main container to network {}: {}",
+        net,
+        stderr.trim()
+    );
+}
+
+/// Start a detached service container on the workspace network with a DNS
+/// alias matching `name`. Returns the host the agent should use plus the
+/// container's full name.
+pub fn start_service(
+    rt: &ContainerRuntime,
+    workspace: &std::path::Path,
+    session_id: &str,
+    image: &str,
+    name: &str,
+    env: &[(String, String)],
+    command: &[String],
+) -> Result<StartedService> {
+    let net = ensure_service_network(rt, workspace)?;
+    connect_main_to_network(rt, workspace, session_id)?;
+
+    let container_name = service_container_name(workspace, session_id, name);
+
+    // Refuse to silently clobber an existing service of the same name.
+    let existing = rt
+        .command()
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("name=^{}$", container_name),
+            "--format",
+            "{{.Names}}",
+        ])
+        .output()
+        .context("failed to check existing service container")?;
+    if !String::from_utf8_lossy(&existing.stdout).trim().is_empty() {
+        anyhow::bail!(
+            "service '{}' already exists for this session; stop it first or pick a different name",
+            name
+        );
+    }
+
+    let mut args: Vec<String> = vec![
+        "run".into(),
+        "-d".into(),
+        "--rm".into(),
+        "--name".into(),
+        container_name.clone(),
+        "--label".into(),
+        "managed-by=ai-pod".into(),
+        "--label".into(),
+        SERVICE_LABEL.into(),
+        "--label".into(),
+        format!("{}={}", PARENT_LABEL_KEY, session_id),
+        "--network".into(),
+        net,
+        "--network-alias".into(),
+        name.to_string(),
+    ];
+    for (k, v) in env {
+        args.push("-e".into());
+        args.push(format!("{}={}", k, v));
+    }
+    args.push(image.to_string());
+    for c in command {
+        args.push(c.clone());
+    }
+
+    let output = rt
+        .command()
+        .args(&args)
+        .output()
+        .context("failed to spawn service container")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "failed to start service container: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(StartedService {
+        host: name.to_string(),
+        container_name,
+    })
+}
+
+/// Stop a service container belonging to `session_id`. Returns true on
+/// successful removal, false if no matching container existed.
+pub fn stop_service(
+    rt: &ContainerRuntime,
+    workspace: &std::path::Path,
+    session_id: &str,
+    name: &str,
+) -> Result<bool> {
+    let container_name = service_container_name(workspace, session_id, name);
+    // Verify ownership: filter by both the expected name and the parent label.
+    let listed = rt
+        .command()
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("name=^{}$", container_name),
+            "--filter",
+            &format!("label={}={}", PARENT_LABEL_KEY, session_id),
+            "--format",
+            "{{.Names}}",
+        ])
+        .output()
+        .context("failed to list service container")?;
+    if String::from_utf8_lossy(&listed.stdout).trim().is_empty() {
+        return Ok(false);
+    }
+    let status = rt
+        .command()
+        .args(["rm", "--force", &container_name])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .context("failed to remove service container")?;
+    Ok(status.success())
+}
+
+/// List service containers owned by `session_id` in `workspace`.
+pub fn list_services(
+    rt: &ContainerRuntime,
+    workspace: &std::path::Path,
+    session_id: &str,
+) -> Result<Vec<ServiceInfo>> {
+    let prefix = format!(
+        "ai-pod-{}-{}-svc-",
+        crate::workspace::workspace_hash(workspace),
+        session_id
+    );
+    let output = rt
+        .command()
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("name=^{}", prefix),
+            "--filter",
+            &format!("label={}={}", PARENT_LABEL_KEY, session_id),
+            "--format",
+            "{{.Names}}\t{{.Image}}\t{{.Status}}",
+        ])
+        .output()
+        .context("failed to list service containers")?;
+    let mut out = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(3, '\t');
+        let container_name = parts.next().unwrap_or("").to_string();
+        let image = parts.next().unwrap_or("").to_string();
+        let status = parts.next().unwrap_or("").to_string();
+        let name = container_name
+            .strip_prefix(&prefix)
+            .unwrap_or(&container_name)
+            .to_string();
+        out.push(ServiceInfo {
+            name,
+            container_name,
+            image,
+            status,
+        });
+    }
+    Ok(out)
+}
+
+/// Fetch the last `lines` lines of a service container's stdout+stderr (podman
+/// merges them in `podman logs --tail`).
+pub fn service_logs(
+    rt: &ContainerRuntime,
+    workspace: &std::path::Path,
+    session_id: &str,
+    name: &str,
+    lines: usize,
+) -> Result<String> {
+    let container_name = service_container_name(workspace, session_id, name);
+    let listed = rt
+        .command()
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("name=^{}$", container_name),
+            "--filter",
+            &format!("label={}={}", PARENT_LABEL_KEY, session_id),
+            "--format",
+            "{{.Names}}",
+        ])
+        .output()
+        .context("failed to list service container")?;
+    if String::from_utf8_lossy(&listed.stdout).trim().is_empty() {
+        anyhow::bail!("no service named '{}' for this session", name);
+    }
+    let output = rt
+        .command()
+        .args(["logs", "--tail", &lines.to_string(), &container_name])
+        .output()
+        .context("failed to read service logs")?;
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    let err = String::from_utf8_lossy(&output.stderr);
+    if !err.trim().is_empty() {
+        if !text.is_empty() && !text.ends_with('\n') {
+            text.push('\n');
+        }
+        text.push_str(&err);
+    }
+    Ok(text)
+}
+
+/// Best-effort removal of every service container labeled with this session
+/// id. Used by the CLI right after the main container exits and by the
+/// server's periodic sweep when the main container is gone.
+pub fn cleanup_services_for_session(rt: &ContainerRuntime, session_id: &str) {
+    let output = rt
+        .command()
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("label={}={}", PARENT_LABEL_KEY, session_id),
+            "--filter",
+            &format!("label={}", SERVICE_LABEL),
+            "--format",
+            "{{.Names}}",
+        ])
+        .output();
+    let names = match output {
+        Ok(o) => o.stdout,
+        Err(_) => return,
+    };
+    for name in String::from_utf8_lossy(&names).lines() {
+        if name.is_empty() {
+            continue;
+        }
+        let _ = rt
+            .command()
+            .args(["rm", "--force", name])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+/// Async sibling of `cleanup_services_for_session` for use from inside the
+/// shared server's tokio runtime.
+pub async fn cleanup_services_for_session_async(rt: &ContainerRuntime, session_id: &str) {
+    let output = rt
+        .async_command()
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("label={}={}", PARENT_LABEL_KEY, session_id),
+            "--filter",
+            &format!("label={}", SERVICE_LABEL),
+            "--format",
+            "{{.Names}}",
+        ])
+        .output()
+        .await;
+    let names = match output {
+        Ok(o) => o.stdout,
+        Err(_) => return,
+    };
+    for name in String::from_utf8_lossy(&names).lines() {
+        if name.is_empty() {
+            continue;
+        }
+        let _ = rt
+            .async_command()
+            .args(["rm", "--force", name])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await;
+    }
+}
+
+/// Remove the per-workspace service network. Best-effort: ignores "not found"
+/// or "in use" errors so callers don't have to special-case the first run.
+pub fn remove_service_network(rt: &ContainerRuntime, workspace: &std::path::Path) {
+    let net = service_network_name(workspace);
+    let _ = rt
+        .command()
+        .args(["network", "rm", &net])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_label_constant_matches_filter_form() {
+        assert_eq!(SERVICE_LABEL, "ai-pod-service=true");
+    }
+
+    #[test]
+    fn parent_label_key_matches_documented_value() {
+        assert_eq!(PARENT_LABEL_KEY, "ai-pod-parent");
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -48,14 +48,23 @@ pub fn ensure_service_network(rt: &ContainerRuntime, workspace: &std::path::Path
     let create = rt
         .command()
         .args(["network", "create", &net])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
+        .output()
         .context("failed to create network")?;
-    if !create.success() {
-        anyhow::bail!("failed to create service network {}", net);
+    if create.status.success() {
+        return Ok(net);
     }
-    Ok(net)
+    // Two concurrent sessions both passing the inspect-then-create check
+    // would otherwise both bail here. Treat "already exists" as success so
+    // the second caller (and our own retries) succeed.
+    let stderr = String::from_utf8_lossy(&create.stderr).to_lowercase();
+    if stderr.contains("already exists") || stderr.contains("already in use") {
+        return Ok(net);
+    }
+    anyhow::bail!(
+        "failed to create service network {}: {}",
+        net,
+        stderr.trim()
+    );
 }
 
 /// Start a detached service container on the workspace network with a DNS

--- a/src/service.rs
+++ b/src/service.rs
@@ -20,6 +20,7 @@ pub const PARENT_LABEL_KEY: &str = "ai-pod-parent";
 
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ServiceInfo {
+    pub session_id: String,
     pub name: String,
     pub container_name: String,
     pub image: String,
@@ -227,6 +228,68 @@ pub fn list_services(
             .unwrap_or(&container_name)
             .to_string();
         out.push(ServiceInfo {
+            session_id: session_id.to_string(),
+            name,
+            container_name,
+            image,
+            status,
+        });
+    }
+    Ok(out)
+}
+
+/// List every service container in `workspace`, across all sessions. Used by
+/// the host-side `ai-pod services` CLI: the host process is not bound to any
+/// one session, so this enumerates all of them and the caller decides what to
+/// do per-row.
+pub fn list_services_for_workspace(
+    rt: &ContainerRuntime,
+    workspace: &std::path::Path,
+) -> Result<Vec<ServiceInfo>> {
+    let workspace_prefix = format!("ai-pod-{}-", crate::workspace::workspace_hash(workspace));
+    let output = rt
+        .command()
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("name=^{}", workspace_prefix),
+            "--filter",
+            &format!("label={}", SERVICE_LABEL),
+            "--format",
+            "{{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Labels}}",
+        ])
+        .output()
+        .context("failed to list workspace service containers")?;
+    let mut out = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(4, '\t');
+        let container_name = parts.next().unwrap_or("").to_string();
+        let image = parts.next().unwrap_or("").to_string();
+        let status = parts.next().unwrap_or("").to_string();
+        let labels = parts.next().unwrap_or("");
+
+        // Recover session_id from the parent label rather than parsing the
+        // name, so a future name-scheme tweak doesn't quietly break this.
+        let session_id = labels
+            .split(',')
+            .find_map(|kv| kv.trim().strip_prefix(&format!("{}=", PARENT_LABEL_KEY)))
+            .unwrap_or("")
+            .to_string();
+        if session_id.is_empty() {
+            continue;
+        }
+
+        let svc_prefix = format!("{}{}-svc-", workspace_prefix, session_id);
+        let name = container_name
+            .strip_prefix(&svc_prefix)
+            .unwrap_or(&container_name)
+            .to_string();
+        out.push(ServiceInfo {
+            session_id,
             name,
             container_name,
             image,

--- a/src/service.rs
+++ b/src/service.rs
@@ -58,72 +58,15 @@ pub fn ensure_service_network(rt: &ContainerRuntime, workspace: &std::path::Path
     Ok(net)
 }
 
-/// Find the running main container for `(workspace, session_id)`. Returns the
-/// container name. Errors if no such container is running.
-pub fn find_main_container(
-    rt: &ContainerRuntime,
-    workspace: &std::path::Path,
-    session_id: &str,
-) -> Result<String> {
-    let expected = crate::workspace::container_name_for(workspace, session_id);
-    let output = rt
-        .command()
-        .args([
-            "ps",
-            "--filter",
-            &format!("name=^{}$", expected),
-            "--filter",
-            "label=managed-by=ai-pod",
-            "--format",
-            "{{.Names}}",
-        ])
-        .output()
-        .context("failed to list main container")?;
-    let name = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .find(|l| !l.is_empty())
-        .map(|l| l.to_string());
-    match name {
-        Some(n) => Ok(n),
-        None => anyhow::bail!(
-            "no running main container for session {} (expected {})",
-            session_id,
-            expected
-        ),
-    }
-}
-
-/// Attach the main container to the workspace network. Idempotent: a second
-/// call swallows the "already attached" error.
-pub fn connect_main_to_network(
-    rt: &ContainerRuntime,
-    workspace: &std::path::Path,
-    session_id: &str,
-) -> Result<()> {
-    let net = service_network_name(workspace);
-    let main = find_main_container(rt, workspace, session_id)?;
-    let output = rt
-        .command()
-        .args(["network", "connect", &net, &main])
-        .output()
-        .context("failed to connect main container to service network")?;
-    if output.status.success() {
-        return Ok(());
-    }
-    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
-    if stderr.contains("already") {
-        return Ok(());
-    }
-    anyhow::bail!(
-        "failed to connect main container to network {}: {}",
-        net,
-        stderr.trim()
-    );
-}
-
 /// Start a detached service container on the workspace network with a DNS
 /// alias matching `name`. Returns the host the agent should use plus the
 /// container's full name.
+///
+/// The main container is expected to already be attached to the workspace
+/// network — `container::launch_container` puts it there at launch time
+/// because lazy attach (`podman network connect ... main`) does not work for
+/// rootless slirp4netns containers. Sessions started by an older ai-pod must
+/// be relaunched before they can use service containers.
 pub fn start_service(
     rt: &ContainerRuntime,
     workspace: &std::path::Path,
@@ -134,8 +77,6 @@ pub fn start_service(
     command: &[String],
 ) -> Result<StartedService> {
     let net = ensure_service_network(rt, workspace)?;
-    connect_main_to_network(rt, workspace, session_id)?;
-
     let container_name = service_container_name(workspace, session_id, name);
 
     // Refuse to silently clobber an existing service of the same name.

--- a/src/services_cli.rs
+++ b/src/services_cli.rs
@@ -1,0 +1,280 @@
+//! Host-side `ai-pod services` subcommand: list, logs, stop, plus a minimal
+//! ratatui TUI that mirrors `ai-pod commands` for visual parity.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Modifier, Style},
+    text::Line,
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+
+use crate::runtime::ContainerRuntime;
+use crate::service::{self, ServiceInfo};
+
+/// Resolve a `name` to a `session_id` for a workspace. If `explicit` is
+/// supplied, it wins. Otherwise we look at every service in the workspace and
+/// only succeed when exactly one matches.
+fn resolve_session(
+    services: &[ServiceInfo],
+    name: &str,
+    explicit: Option<&str>,
+) -> Result<String> {
+    if let Some(s) = explicit {
+        return Ok(s.to_string());
+    }
+    let matches: Vec<&ServiceInfo> = services.iter().filter(|s| s.name == name).collect();
+    match matches.len() {
+        0 => anyhow::bail!("No service named '{}' in this workspace.", name),
+        1 => Ok(matches[0].session_id.clone()),
+        n => {
+            let ids: Vec<&str> = matches.iter().map(|s| s.session_id.as_str()).collect();
+            anyhow::bail!(
+                "{} services named '{}' across sessions [{}]; pass --session to disambiguate.",
+                n,
+                name,
+                ids.join(", ")
+            )
+        }
+    }
+}
+
+pub fn run_list(rt: &ContainerRuntime, workspace: &Path) -> Result<()> {
+    let services = service::list_services_for_workspace(rt, workspace)?;
+    if services.is_empty() {
+        println!("{}", "No services found.".yellow());
+        return Ok(());
+    }
+    println!(
+        "{:<16} {:<10} {:<30} {}",
+        "NAME".bold(),
+        "SESSION".bold(),
+        "IMAGE".bold(),
+        "STATUS".bold(),
+    );
+    for s in &services {
+        let img_short = if s.image.len() > 28 {
+            format!("{}…", &s.image[..27])
+        } else {
+            s.image.clone()
+        };
+        println!(
+            "{:<16} {:<10} {:<30} {}",
+            s.name, s.session_id, img_short, s.status,
+        );
+    }
+    Ok(())
+}
+
+pub fn run_logs(
+    rt: &ContainerRuntime,
+    workspace: &Path,
+    name: &str,
+    session: Option<&str>,
+    lines: usize,
+) -> Result<()> {
+    let services = service::list_services_for_workspace(rt, workspace)?;
+    let session_id = resolve_session(&services, name, session)?;
+    let logs = service::service_logs(rt, workspace, &session_id, name, lines)
+        .context("failed to read service logs")?;
+    println!("{} {}", "session:".blue().bold(), session_id);
+    println!("{} {}", "service:".blue().bold(), name);
+    println!("{}", "--- logs ---".dimmed());
+    print!("{}", logs);
+    if !logs.ends_with('\n') {
+        println!();
+    }
+    Ok(())
+}
+
+pub fn run_stop(
+    rt: &ContainerRuntime,
+    workspace: &Path,
+    name: &str,
+    session: Option<&str>,
+) -> Result<()> {
+    let services = service::list_services_for_workspace(rt, workspace)?;
+    let session_id = resolve_session(&services, name, session)?;
+    let stopped = service::stop_service(rt, workspace, &session_id, name)?;
+    if stopped {
+        println!("{} {} (session {})", "Stopped:".green(), name, session_id);
+    } else {
+        println!(
+            "{} {} (session {}) — already gone?",
+            "Not running:".yellow(),
+            name,
+            session_id
+        );
+    }
+    Ok(())
+}
+
+// ---------------- TUI ----------------
+
+pub fn run_tui(rt: &ContainerRuntime, workspace: &Path) -> Result<()> {
+    enable_raw_mode().context("enable raw mode")?;
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen).context("enter alt screen")?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("create terminal")?;
+
+    let result = tui_loop(&mut terminal, rt, workspace);
+
+    disable_raw_mode().ok();
+    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+    terminal.show_cursor().ok();
+
+    result
+}
+
+struct TuiState {
+    items: Vec<ServiceInfo>,
+    list_state: ListState,
+    last_refresh: Instant,
+    log_buf: String,
+}
+
+fn fetch_logs(rt: &ContainerRuntime, workspace: &Path, s: &TuiState) -> String {
+    let idx = match s.list_state.selected() {
+        Some(i) => i,
+        None => return String::new(),
+    };
+    let svc = match s.items.get(idx) {
+        Some(s) => s,
+        None => return String::new(),
+    };
+    service::service_logs(rt, workspace, &svc.session_id, &svc.name, 200)
+        .unwrap_or_default()
+}
+
+fn tui_loop(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    rt: &ContainerRuntime,
+    workspace: &Path,
+) -> Result<()> {
+    let mut s = TuiState {
+        items: Vec::new(),
+        list_state: ListState::default(),
+        last_refresh: Instant::now() - Duration::from_secs(60),
+        log_buf: String::new(),
+    };
+
+    loop {
+        if s.last_refresh.elapsed() > Duration::from_millis(750) {
+            if let Ok(items) = service::list_services_for_workspace(rt, workspace) {
+                s.items = items;
+                if s.list_state.selected().is_none() && !s.items.is_empty() {
+                    s.list_state.select(Some(0));
+                }
+                if let Some(idx) = s.list_state.selected() {
+                    if idx >= s.items.len() && !s.items.is_empty() {
+                        s.list_state.select(Some(s.items.len() - 1));
+                    }
+                }
+                s.log_buf = fetch_logs(rt, workspace, &s);
+            }
+            s.last_refresh = Instant::now();
+        }
+
+        terminal.draw(|f| {
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+                .split(f.area());
+
+            let items: Vec<ListItem> = s
+                .items
+                .iter()
+                .map(|svc| {
+                    let icon = if svc.status.starts_with("Up") || svc.status.starts_with("running")
+                    {
+                        "▶"
+                    } else {
+                        "⏹"
+                    };
+                    let img_short = if svc.image.len() > 24 {
+                        format!("{}…", &svc.image[..23])
+                    } else {
+                        svc.image.clone()
+                    };
+                    ListItem::new(format!(
+                        "{} {} {} {}",
+                        icon, svc.name, svc.session_id, img_short
+                    ))
+                })
+                .collect();
+
+            let list = List::new(items)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title("services  (↑/↓ select, k kill, r refresh, q quit)"),
+                )
+                .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+            f.render_stateful_widget(list, chunks[0], &mut s.list_state);
+
+            let para = Paragraph::new(
+                s.log_buf
+                    .lines()
+                    .rev()
+                    .take(chunks[1].height as usize)
+                    .map(|l| Line::from(l.to_string()))
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect::<Vec<_>>(),
+            )
+            .block(Block::default().borders(Borders::ALL).title("logs"));
+            f.render_widget(para, chunks[1]);
+        })?;
+
+        if event::poll(Duration::from_millis(250))? {
+            if let Event::Key(KeyEvent { code, kind, .. }) = event::read()? {
+                if kind != KeyEventKind::Press {
+                    continue;
+                }
+                match code {
+                    KeyCode::Char('q') | KeyCode::Esc => break,
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if !s.items.is_empty() {
+                            let cur = s.list_state.selected().unwrap_or(0);
+                            let next = (cur + 1).min(s.items.len().saturating_sub(1));
+                            s.list_state.select(Some(next));
+                            s.log_buf = fetch_logs(rt, workspace, &s);
+                        }
+                    }
+                    KeyCode::Up | KeyCode::Char('K') => {
+                        let cur = s.list_state.selected().unwrap_or(0);
+                        s.list_state.select(Some(cur.saturating_sub(1)));
+                        s.log_buf = fetch_logs(rt, workspace, &s);
+                    }
+                    KeyCode::Char('k') => {
+                        if let Some(idx) = s.list_state.selected() {
+                            if let Some(svc) = s.items.get(idx).cloned() {
+                                let _ =
+                                    service::stop_service(rt, workspace, &svc.session_id, &svc.name);
+                                s.last_refresh = Instant::now() - Duration::from_secs(60);
+                            }
+                        }
+                    }
+                    KeyCode::Char('r') => {
+                        s.last_refresh = Instant::now() - Duration::from_secs(60);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -47,6 +47,61 @@ pub fn mask_volume_name(workspace: &Path, dir: &str) -> String {
     format!("ai-pod-{}-mask-{}", workspace_hash(workspace), dir)
 }
 
+/// Per-workspace bridge network used to wire service containers to the
+/// running main container so the agent can reach them by name.
+pub fn service_network_name(workspace: &Path) -> String {
+    format!("ai-pod-{}-net", workspace_hash(workspace))
+}
+
+/// Container name for a service requested by the given main-container session.
+/// Embedding the session id keeps two concurrent ai-pod sessions on the same
+/// workspace from colliding on the same service name.
+pub fn service_container_name(workspace: &Path, session_id: &str, name: &str) -> String {
+    format!(
+        "ai-pod-{}-{}-svc-{}",
+        workspace_hash(workspace),
+        session_id,
+        name
+    )
+}
+
+/// Validate a user-supplied service name. Returns the trimmed name on success.
+///
+/// Rules: 1..=30 ASCII chars, lowercase alphanumeric or `-`, must start with an
+/// alphanumeric. Doubles as DNS alias on the workspace network, so we keep it
+/// to a strict subset of RFC 1123 hostname rules. The 30-char cap keeps the
+/// derived container name under podman/docker's 63-char limit.
+pub fn validate_service_name(name: &str) -> Result<&str, String> {
+    if name.is_empty() {
+        return Err("service name must not be empty".into());
+    }
+    if name.len() > 30 {
+        return Err(format!(
+            "service name '{}' too long ({} chars, max 30)",
+            name,
+            name.len()
+        ));
+    }
+    let mut chars = name.chars();
+    let first = chars.next().unwrap();
+    if !first.is_ascii_alphanumeric() {
+        return Err(format!(
+            "service name '{}' must start with a lowercase letter or digit",
+            name
+        ));
+    }
+    for c in name.chars() {
+        let ok = c.is_ascii_digit() || (c.is_ascii_alphabetic() && c.is_ascii_lowercase()) || c == '-';
+        if !ok {
+            return Err(format!(
+                "service name '{}' contains invalid character '{}' (only [a-z0-9-] allowed)",
+                name, c
+            ));
+        }
+    }
+    Ok(name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,5 +167,69 @@ mod tests {
         let a = container_prefix(Path::new("/home/user/project-a"));
         let b = container_prefix(Path::new("/home/user/project-b"));
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn service_network_name_is_per_workspace() {
+        let p = Path::new("/home/user/myproject");
+        assert_eq!(
+            service_network_name(p),
+            format!("ai-pod-{}-net", workspace_hash(p))
+        );
+        let other = Path::new("/home/user/other");
+        assert_ne!(service_network_name(p), service_network_name(other));
+    }
+
+    #[test]
+    fn service_container_name_embeds_workspace_and_session() {
+        let p = Path::new("/home/user/myproject");
+        assert_eq!(
+            service_container_name(p, "abcd1234", "postgres"),
+            format!("ai-pod-{}-abcd1234-svc-postgres", workspace_hash(p))
+        );
+    }
+
+    #[test]
+    fn service_container_name_differs_between_sessions() {
+        let p = Path::new("/home/user/myproject");
+        assert_ne!(
+            service_container_name(p, "aaaa1111", "postgres"),
+            service_container_name(p, "bbbb2222", "postgres"),
+        );
+    }
+
+    #[test]
+    fn service_container_name_stays_under_docker_limit() {
+        let p = Path::new("/home/user/myproject");
+        let name = service_container_name(p, "abcd1234", &"x".repeat(30));
+        assert!(name.len() <= 63, "got {} chars: {}", name.len(), name);
+    }
+
+    #[test]
+    fn validate_service_name_accepts_typical_names() {
+        assert!(validate_service_name("postgres").is_ok());
+        assert!(validate_service_name("redis").is_ok());
+        assert!(validate_service_name("redis-7").is_ok());
+        assert!(validate_service_name("db1").is_ok());
+        assert!(validate_service_name("a").is_ok());
+    }
+
+    #[test]
+    fn validate_service_name_rejects_uppercase_and_punctuation() {
+        assert!(validate_service_name("Postgres").is_err());
+        assert!(validate_service_name("pg/x").is_err());
+        assert!(validate_service_name("pg_x").is_err());
+        assert!(validate_service_name("pg.x").is_err());
+    }
+
+    #[test]
+    fn validate_service_name_rejects_empty_and_too_long() {
+        assert!(validate_service_name("").is_err());
+        assert!(validate_service_name(&"a".repeat(31)).is_err());
+    }
+
+    #[test]
+    fn validate_service_name_rejects_leading_dash() {
+        assert!(validate_service_name("-postgres").is_err());
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -82,9 +82,8 @@ pub fn validate_service_name(name: &str) -> Result<&str, String> {
             name.len()
         ));
     }
-    let mut chars = name.chars();
-    let first = chars.next().unwrap();
-    if !first.is_ascii_alphanumeric() {
+    let first = name.chars().next().unwrap();
+    if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
         return Err(format!(
             "service name '{}' must start with a lowercase letter or digit",
             name
@@ -220,6 +219,15 @@ mod tests {
         assert!(validate_service_name("pg/x").is_err());
         assert!(validate_service_name("pg_x").is_err());
         assert!(validate_service_name("pg.x").is_err());
+    }
+
+    #[test]
+    fn validate_service_name_uppercase_first_char_message_blames_first_char() {
+        let err = validate_service_name("Postgres").unwrap_err();
+        assert!(
+            err.contains("must start with a lowercase letter or digit"),
+            "expected first-char error for uppercase first letter, got: {err}"
+        );
     }
 
     #[test]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -601,9 +601,12 @@ fn cleanup_network(rt: &ContainerRuntime, name: &str) {
 }
 
 /// Stand up a fake "main" container (sleeping) named like an ai-pod container
-/// so the service module's helpers can find it.
+/// so the service module's helpers can find it. Mirrors what production's
+/// `container::launch_container` does: ensures the per-workspace service
+/// network exists and attaches the main to it at launch time.
 fn start_fake_main(rt: &ContainerRuntime, workspace: &Path, session_id: &str) -> String {
     let name = workspace::container_name_for(workspace, session_id);
+    let net = service::ensure_service_network(rt, workspace).expect("ensure service network");
     let img = SERVICE_TEST_IMAGE;
     let _ = rt.command().args(["pull", img]).output();
     let status = rt
@@ -616,6 +619,8 @@ fn start_fake_main(rt: &ContainerRuntime, workspace: &Path, session_id: &str) ->
             &name,
             "--label",
             "managed-by=ai-pod",
+            "--network",
+            &net,
             img,
             "sleep",
             "600",

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -589,3 +589,259 @@ async fn e2e_server_reachable_from_container() {
 // Agent install tests (claude + opencode across all base images) are in
 // tests/e2e_agents.sh — a shell script that exercises `ai-pod init` for
 // every agent × image combination and verifies the agent binary runs.
+
+// ---------------------------------------------------------------------------
+// Service container tests
+// ---------------------------------------------------------------------------
+
+use ai_pod::service;
+
+fn cleanup_network(rt: &ContainerRuntime, name: &str) {
+    let _ = rt.command().args(["network", "rm", "-f", name]).output();
+}
+
+/// Stand up a fake "main" container (sleeping) named like an ai-pod container
+/// so the service module's helpers can find it.
+fn start_fake_main(rt: &ContainerRuntime, workspace: &Path, session_id: &str) -> String {
+    let name = workspace::container_name_for(workspace, session_id);
+    let img = SERVICE_TEST_IMAGE;
+    let _ = rt.command().args(["pull", img]).output();
+    let status = rt
+        .command()
+        .args([
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            &name,
+            "--label",
+            "managed-by=ai-pod",
+            img,
+            "sleep",
+            "600",
+        ])
+        .output()
+        .expect("spawn fake main");
+    assert!(
+        status.status.success(),
+        "fake main container failed to start: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    name
+}
+
+/// Container image used by the service e2e tests. Picked because the sandbox
+/// only allows the Microsoft Container Registry; Docker Hub's CDN is blocked.
+/// The image just needs `sh` and `sleep`/`getent` for the assertions below.
+const SERVICE_TEST_IMAGE: &str = "mcr.microsoft.com/cbl-mariner/base/core:2.0";
+
+/// `ensure_service_network` creates the network when missing and is idempotent.
+#[test]
+fn e2e_service_network_create_idempotent() {
+    let rt = require_runtime!();
+    let ws_dir = tempfile::TempDir::new().unwrap();
+    let workspace = ws_dir.path();
+    let net = workspace::service_network_name(workspace);
+    cleanup_network(&rt, &net);
+
+    let n1 = service::ensure_service_network(&rt, workspace).unwrap();
+    let n2 = service::ensure_service_network(&rt, workspace).unwrap();
+    assert_eq!(n1, net);
+    assert_eq!(n2, net);
+
+    let status = rt
+        .command()
+        .args(["network", "inspect", &net])
+        .stdout(std::process::Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "network should exist after ensure");
+
+    cleanup_network(&rt, &net);
+}
+
+/// Start a service container, verify the main container can reach it by name,
+/// then tear it down via `cleanup_services_for_session`.
+#[test]
+fn e2e_service_start_reach_cleanup() {
+    let rt = require_runtime!();
+    let ws_dir = tempfile::TempDir::new().unwrap();
+    let workspace = ws_dir.path();
+    let session_id = "e2etest0";
+    let net = workspace::service_network_name(workspace);
+    let main_name = workspace::container_name_for(workspace, session_id);
+    let svc_container = workspace::service_container_name(workspace, session_id, "db");
+
+    cleanup_container(&rt, &main_name);
+    cleanup_container(&rt, &svc_container);
+    cleanup_network(&rt, &net);
+
+    let _ = start_fake_main(&rt, workspace, session_id);
+
+    let started = service::start_service(
+        &rt,
+        workspace,
+        session_id,
+        SERVICE_TEST_IMAGE,
+        "db",
+        &[("MARKER".to_string(), "hello".to_string())],
+        &["sleep".into(), "600".into()],
+    )
+    .expect("start_service");
+    assert_eq!(started.host, "db");
+    assert_eq!(started.container_name, svc_container);
+
+    // Verify the service has the right labels.
+    let inspect = rt
+        .command()
+        .args([
+            "inspect",
+            "--format",
+            "{{.Config.Labels}}",
+            &svc_container,
+        ])
+        .output()
+        .unwrap();
+    let labels = String::from_utf8_lossy(&inspect.stdout);
+    assert!(labels.contains("ai-pod-service:true"), "labels: {labels}");
+    assert!(
+        labels.contains(&format!("ai-pod-parent:{session_id}")),
+        "labels: {labels}"
+    );
+
+    // The main container should now resolve `db` to the service's IP via
+    // docker's embedded DNS on the per-workspace network. Retry briefly to
+    // give the DNS record time to propagate after `network connect`.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let mut resolved = false;
+    let mut last_output = String::new();
+    while std::time::Instant::now() < deadline {
+        let out = rt
+            .command()
+            .args(["exec", &main_name, "getent", "hosts", "db"])
+            .output();
+        if let Ok(o) = out {
+            if o.status.success() && !o.stdout.is_empty() {
+                resolved = true;
+                last_output = String::from_utf8_lossy(&o.stdout).into_owned();
+                break;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    assert!(
+        resolved,
+        "main container could not resolve `db` within 15s (last output: {last_output:?})"
+    );
+
+    // list_services should see exactly our one service for this session.
+    let listed = service::list_services(&rt, workspace, session_id).unwrap();
+    assert_eq!(listed.len(), 1, "expected 1 service, got {:?}", listed);
+    assert_eq!(listed[0].name, "db");
+    assert_eq!(listed[0].image, SERVICE_TEST_IMAGE);
+
+    // Cleanup: simulate session end.
+    service::cleanup_services_for_session(&rt, session_id);
+
+    let listed_after = service::list_services(&rt, workspace, session_id).unwrap();
+    assert!(
+        listed_after.is_empty(),
+        "service should be gone after cleanup: {:?}",
+        listed_after
+    );
+
+    cleanup_container(&rt, &main_name);
+    cleanup_network(&rt, &net);
+}
+
+/// `stop_service` refuses to touch a service tagged with a different parent.
+#[test]
+fn e2e_service_stop_respects_parent_label() {
+    let rt = require_runtime!();
+    let ws_dir = tempfile::TempDir::new().unwrap();
+    let workspace = ws_dir.path();
+    let session_a = "aaaa0001";
+    let session_b = "bbbb0002";
+    let net = workspace::service_network_name(workspace);
+    let main_a = workspace::container_name_for(workspace, session_a);
+    let svc_a = workspace::service_container_name(workspace, session_a, "svc");
+
+    cleanup_container(&rt, &main_a);
+    cleanup_container(&rt, &svc_a);
+    cleanup_network(&rt, &net);
+
+    let _ = start_fake_main(&rt, workspace, session_a);
+    service::start_service(
+        &rt,
+        workspace,
+        session_a,
+        SERVICE_TEST_IMAGE,
+        "svc",
+        &[],
+        &["sleep".into(), "600".into()],
+    )
+    .expect("start_service for session A");
+
+    // Session B tries to stop session A's service — same workspace, different
+    // session id. The derived container name won't match (session id is in
+    // the name), so stop_service returns false without touching anything.
+    let stopped = service::stop_service(&rt, workspace, session_b, "svc").unwrap();
+    assert!(!stopped, "session B should not be able to stop A's service");
+    // Service still alive.
+    let listed = service::list_services(&rt, workspace, session_a).unwrap();
+    assert_eq!(listed.len(), 1);
+
+    // Session A can stop its own.
+    let stopped_a = service::stop_service(&rt, workspace, session_a, "svc").unwrap();
+    assert!(stopped_a);
+
+    cleanup_container(&rt, &main_a);
+    cleanup_network(&rt, &net);
+}
+
+/// `start_service` rejects a second start with the same name in the same session.
+#[test]
+fn e2e_service_name_collision_within_session() {
+    let rt = require_runtime!();
+    let ws_dir = tempfile::TempDir::new().unwrap();
+    let workspace = ws_dir.path();
+    let session_id = "coll0001";
+    let net = workspace::service_network_name(workspace);
+    let main_name = workspace::container_name_for(workspace, session_id);
+    let svc_container = workspace::service_container_name(workspace, session_id, "dup");
+
+    cleanup_container(&rt, &main_name);
+    cleanup_container(&rt, &svc_container);
+    cleanup_network(&rt, &net);
+
+    let _ = start_fake_main(&rt, workspace, session_id);
+    service::start_service(
+        &rt,
+        workspace,
+        session_id,
+        SERVICE_TEST_IMAGE,
+        "dup",
+        &[],
+        &["sleep".into(), "600".into()],
+    )
+    .expect("first start");
+
+    let err = service::start_service(
+        &rt,
+        workspace,
+        session_id,
+        SERVICE_TEST_IMAGE,
+        "dup",
+        &[],
+        &["sleep".into(), "600".into()],
+    )
+    .expect_err("second start should fail");
+    assert!(
+        err.to_string().contains("already exists"),
+        "expected name-collision error, got: {err}"
+    );
+
+    service::cleanup_services_for_session(&rt, session_id);
+    cleanup_container(&rt, &main_name);
+    cleanup_network(&rt, &net);
+}


### PR DESCRIPTION
## Summary

Implements #89: the in-container agent can now request auxiliary service
containers (postgres, redis, …) over MCP. Four new tools:

- `start_service { image, name, env?, command? }` → returns
  `{ host, container_name }`. The agent reaches the service by `name`
  on the service's standard port (e.g. `postgres:5432`).
- `stop_service { name }`
- `list_services {}`
- `service_logs { name, lines? }`

Service containers live on a per-workspace bridge network
(`ai-pod-{hash}-net`); the main ai-pod container is connected lazily on
the first `start_service`. Each service is labeled
`ai-pod-parent={session_id}` so it can be reaped precisely when the
owning session ends, even with multiple concurrent ai-pod sessions on
the same workspace.

Approval reuses the existing notification flow. The user approves the
canonical string `image with env [SORTED, KEYS]` once per workspace;
values never enter the on-disk allowlist (`allowed_services` field added
to `ProjectState`, additive via `#[serde(default)]`).

Cleanup runs on three paths: (1) CLI tears down its session's services
right after the main container exits, (2) the shared server's existing
60s task now sweeps services whose parent main container is gone, and
(3) `ai-pod clean` removes the per-workspace network alongside the home
and mask volumes.

## Design choices (explicit, see issue thread)

- Per-workspace bridge network + DNS names (not host port mapping).
- Ephemeral data: new anonymous volume per session, discarded on exit.
- Approval key = image + sorted env-var KEY names (values stay private).
- Per-session ownership label so two concurrent sessions don't interfere.

## Test plan

- [x] `cargo test --lib` — 131 unit tests pass, including new coverage of
      `validate_service_name`, `service_approval_key`,
      `ProjectState::allowed_services` (with legacy-file round-trip), and
      the new MCP tool registrations.
- [x] `cargo build` + `cargo build --bins` clean.
- [x] `cargo clippy --all-targets` — no new warnings from the diff.
- [ ] Manual end-to-end (Podman): `ai-pod`, agent calls `start_service`
      with `postgres:16` + `POSTGRES_PASSWORD`, approve, run
      `pg_isready -h postgres` from inside the container, exit, verify
      service container removed. Repeat with same env keys → auto-approve.
- [ ] Manual: SIGKILL ai-pod mid-session, confirm the shared server's
      sweep reaps the orphan within ~60s.
- [ ] Manual: two concurrent sessions on the same workspace each start a
      service with a different name; verify isolation and per-session
      cleanup.
- [ ] Manual: `ai-pod clean` removes the per-workspace network.

https://claude.ai/code/session_01M4nXgpZPeCDRoKYX3Wg8NZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4nXgpZPeCDRoKYX3Wg8NZ)_