### PR TITLE
fix: address PR #94 review (mount validation + stored-state hardening)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,6 +211,10 @@ pub enum MountAction {
         /// Mount as read-write (default: read-only)
         #[arg(long)]
         writable: bool,
+        /// Skip the interactive confirmation when the path matches a built-in
+        /// warn-list (credentials, system paths, ai-pod's own state, etc.).
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
     /// Remove a mount by host path (use the exact host path from `mount list`).
     Remove {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 pub struct AppConfig {
@@ -79,6 +79,11 @@ impl GlobalConfig {
         file.write_all(json.as_bytes())
             .context("Failed to write global config contents")?;
         std::fs::rename(&tmp, &path).context("Failed to rename global config")?;
+        // `.mode(0o600)` only takes effect on O_CREAT; a stale tmp from a
+        // crashed earlier run keeps its old mode through truncate. Re-apply
+        // explicitly so the rename target is always 0o600.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .context("Failed to set permissions on global config")?;
         Ok(())
     }
 
@@ -315,5 +320,29 @@ mod tests {
         std::fs::write(GlobalConfig::path(&config), "{not valid json").unwrap();
         let loaded = GlobalConfig::load(&config);
         assert!(loaded.mounts.is_empty());
+    }
+
+    #[test]
+    fn global_config_save_overwrites_stale_tmp_with_0o600() {
+        // Simulate a stale tmp file from a crashed earlier save with
+        // permissive bits. The `.mode(0o600)` on OpenOptions only takes
+        // effect on O_CREAT, so without the explicit set_permissions after
+        // rename the final file would inherit the looser mode.
+        let dir = TempDir::new().unwrap();
+        let config = temp_config(&dir);
+        config.init().unwrap();
+        let tmp = GlobalConfig::path(&config).with_extension("tmp");
+        std::fs::write(&tmp, "stale").unwrap();
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let gc = GlobalConfig::default();
+        gc.save(&config).unwrap();
+
+        let mode = std::fs::metadata(GlobalConfig::path(&config))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "save must enforce 0o600 even over a stale tmp");
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -142,6 +142,14 @@ pub(crate) fn resolve_container_target(spec: &MountSpec, home_dir: &Path) -> Res
             spec.host
         )
     })?;
+    if rel.as_os_str().is_empty() {
+        // host == home_dir → "/home/ai-pod/" would mount on top of the seeded
+        // home volume root, hiding .claude/settings.json, .claude.json, etc.
+        anyhow::bail!(
+            "mount {} resolves to the home volume root; mount a sub-path instead",
+            spec.host
+        );
+    }
     Ok(format!("{}/{}", CONTAINER_HOME, rel.display()))
 }
 
@@ -157,8 +165,26 @@ pub(crate) fn resolve_container_target(spec: &MountSpec, home_dir: &Path) -> Res
 pub(crate) fn build_mount_args(home_dir: &Path, mounts: &[MountSpec]) -> Result<Vec<String>> {
     let mut out = Vec::with_capacity(mounts.len() * 2);
     for m in mounts {
-        let host = Path::new(&m.host);
-        if !host.exists() {
+        // Re-validate against the current $HOME and the current rule set so
+        // a stale or hand-edited `~/.ai-pod/config.json` can't bypass the
+        // checks. Failures warn-and-skip so one bad entry doesn't brick
+        // every launch.
+        let target = match crate::mount_cli::validate_spec(m, home_dir) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!(
+                    "{} mount {}: {}; skipping",
+                    "warning:".yellow().bold(),
+                    m.host,
+                    e
+                );
+                continue;
+            }
+        };
+        // symlink_metadata so a dangling symlink (target temporarily missing)
+        // still counts as present — `MountSpec`'s doc comment says symlinks
+        // are intentionally not resolved.
+        if Path::new(&m.host).symlink_metadata().is_err() {
             eprintln!(
                 "{} mount source {} does not exist; skipping",
                 "warning:".yellow().bold(),
@@ -166,7 +192,6 @@ pub(crate) fn build_mount_args(home_dir: &Path, mounts: &[MountSpec]) -> Result<
             );
             continue;
         }
-        let target = resolve_container_target(m, home_dir)?;
         let opts = if m.writable { "z" } else { "z,ro" };
         out.push("-v".to_string());
         out.push(format!("{}:{}:{}", m.host, target, opts));
@@ -1212,5 +1237,69 @@ mod tests {
         }];
         let args = build_mount_args(dir.path(), &mounts).unwrap();
         assert!(args.is_empty(), "missing host path should be skipped");
+    }
+
+    #[test]
+    fn resolve_container_target_rejects_home_root() {
+        // mount add ~ → empty rel → would produce "/home/ai-pod/" and
+        // shadow the seeded volume.
+        let spec = MountSpec {
+            host: "/home/user".into(),
+            container: None,
+            writable: false,
+        };
+        let err = resolve_container_target(&spec, Path::new("/home/user")).unwrap_err();
+        assert!(err.to_string().contains("home volume root"), "got: {err}");
+    }
+
+    #[test]
+    fn build_mount_args_warn_skips_outside_home_when_no_container() {
+        // Regression for the "stored mount bricks every launch" issue:
+        // a hand-synced config.json where `container == None` and `host`
+        // falls outside the *current* $HOME must not error — it should
+        // warn-skip like a missing host.
+        let dir = TempDir::new().unwrap();
+        let outside = dir.path().join("..").join("outside");
+        let mounts = vec![MountSpec {
+            host: outside.display().to_string(),
+            container: None,
+            writable: false,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert!(args.is_empty(), "invalid stored mount should be skipped");
+    }
+
+    #[test]
+    fn build_mount_args_warn_skips_invalid_stored_spec() {
+        // A spec that would have been rejected at `mount add` (here: `/` as
+        // host) but got past validation via hand-edited config.json must be
+        // dropped at launch.
+        let dir = TempDir::new().unwrap();
+        let mounts = vec![MountSpec {
+            host: "/".into(),
+            container: Some("/home/ai-pod/exploit".into()),
+            writable: false,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert!(args.is_empty(), "stored invalid host should be warn-skipped");
+    }
+
+    #[test]
+    fn build_mount_args_keeps_dangling_symlinks() {
+        // MountSpec doc explicitly says symlinks are not resolved, so a
+        // symlink whose target is temporarily missing should still mount.
+        use std::os::unix::fs::symlink;
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("link-to-nothing");
+        symlink(dir.path().join("does-not-exist"), &link).unwrap();
+        let host_str = link.to_string_lossy().to_string();
+        let mounts = vec![MountSpec {
+            host: host_str.clone(),
+            container: Some("/home/ai-pod/.claude/skills".into()),
+            writable: false,
+        }];
+        let args = build_mount_args(dir.path(), &mounts).unwrap();
+        assert_eq!(args.len(), 2, "dangling symlink should still mount");
+        assert!(args[1].starts_with(&host_str));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,8 +341,8 @@ async fn main() -> Result<()> {
             config.init()?;
             match action {
                 MountAction::List => mount_cli::run_list(&config)?,
-                MountAction::Add { spec, writable } => {
-                    mount_cli::run_add(&config, spec, *writable)?
+                MountAction::Add { spec, writable, yes } => {
+                    mount_cli::run_add(&config, spec, *writable, *yes)?
                 }
                 MountAction::Remove { host } => mount_cli::run_remove(&config, host)?,
             }

--- a/src/mount_cli.rs
+++ b/src/mount_cli.rs
@@ -163,6 +163,19 @@ pub(crate) fn validate_container_path(p: &str) -> Result<()> {
     Ok(())
 }
 
+/// Resolve `host` through any symlink chain and return the canonical
+/// absolute path as a string. Returns `None` if the path does not exist
+/// yet (canonicalize requires every component to exist) or if resolution
+/// fails for any other reason. The intentional design point of `MountSpec`
+/// is that the *stored* host string keeps the user's literal symlink
+/// path; this helper exists so the validators and warn-list can also see
+/// where that path *actually* points.
+pub(crate) fn canonical_host(host: &str) -> Option<String> {
+    std::fs::canonicalize(host)
+        .ok()
+        .map(|p| p.display().to_string())
+}
+
 /// Re-run all validators against a stored `MountSpec`, returning the resolved
 /// container target on success. Called both at `mount add` time (via
 /// [`parse_spec`]) and at every container launch by
@@ -170,6 +183,24 @@ pub(crate) fn validate_container_path(p: &str) -> Result<()> {
 /// can't bypass the security and footgun checks.
 pub(crate) fn validate_spec(spec: &MountSpec, home_dir: &Path) -> Result<String> {
     validate_host_path(&spec.host)?;
+    // If the host source resolves through symlinks to a different path,
+    // re-run the host-side string checks against the *resolved* target so
+    // a pre-existing `~/innocent → /etc` (or `→ /`) can't slip past. The
+    // stored `MountSpec.host` is left as the literal user input by design
+    // — this only gates the security/footgun rules. Skipped when the path
+    // doesn't exist yet; launch time gets another shot.
+    if let Some(canonical) = canonical_host(&spec.host) {
+        if canonical != spec.host {
+            validate_host_path(&canonical).map_err(|e| {
+                anyhow::anyhow!(
+                    "host path {} resolves via symlinks to {}: {}",
+                    spec.host,
+                    canonical,
+                    e
+                )
+            })?;
+        }
+    }
     if let Some(c) = &spec.container {
         validate_container_path(c)?;
     } else {
@@ -201,8 +232,25 @@ pub(crate) fn validate_spec(spec: &MountSpec, home_dir: &Path) -> Result<String>
 /// This is the place to teach ai-pod about new risky paths — every entry
 /// becomes an interactive confirmation gate at `mount add` time.
 pub(crate) fn warn_for_spec(spec: &MountSpec, target: &str, home_dir: &Path) -> Vec<String> {
+    let mut out = collect_host_warnings(&spec.host, target, home_dir);
+    if let Some(canonical) = canonical_host(&spec.host) {
+        if canonical != spec.host {
+            for w in collect_host_warnings(&canonical, target, home_dir) {
+                let tagged = format!(
+                    "[host {} resolves via symlinks to {}] {}",
+                    spec.host, canonical, w
+                );
+                if !out.iter().any(|existing| existing == &tagged) {
+                    out.push(tagged);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn collect_host_warnings(host: &str, target: &str, home_dir: &Path) -> Vec<String> {
     let mut out = Vec::new();
-    let host = spec.host.as_str();
 
     // 1. Well-known credential dirs / files under $HOME. These are the
     //    obvious sources of host-wide compromise if exposed to the agent.
@@ -244,6 +292,14 @@ pub(crate) fn warn_for_spec(spec: &MountSpec, target: &str, home_dir: &Path) -> 
         "/root",
         "/var/lib/docker",
         "/var/lib/containers",
+        // macOS canonicalizes /etc → /private/etc, /var/run → /private/var/run,
+        // /tmp → /private/tmp. Include the resolved forms so the
+        // symlink-resolution path of `warn_for_spec` lights up the same way
+        // as on Linux.
+        "/private/etc",
+        "/private/var/run",
+        "/private/var/lib/docker",
+        "/private/var/lib/containers",
     ];
     for sys in system_prefixes {
         if host == sys || host.starts_with(&format!("{}/", sys)) {
@@ -835,6 +891,52 @@ mod tests {
                 w
             );
         }
+    }
+
+    #[test]
+    fn validate_spec_rejects_symlink_to_filesystem_root() {
+        // The original #1 bypass: a `mount add ~/innocent` where the
+        // host path is itself a symlink to `/`. Without canonical-host
+        // re-validation this would have been accepted and podman would
+        // bind-mount the entire host filesystem.
+        use std::os::unix::fs::symlink;
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("innocent");
+        symlink("/", &link).unwrap();
+        let spec = MountSpec {
+            host: link.display().to_string(),
+            container: Some("/home/ai-pod/innocent".into()),
+            writable: false,
+        };
+        let err = validate_spec(&spec, dir.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("resolves via symlinks to"),
+            "expected canonical-resolved rejection, got: {}",
+            err
+        );
+        assert!(err.to_string().contains("filesystem root"), "got: {}", err);
+    }
+
+    #[test]
+    fn warn_fires_when_symlink_resolves_to_system_path() {
+        // `~/notes → /etc`: warn-list must look through the symlink, not
+        // just the literal path string.
+        use std::os::unix::fs::symlink;
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("notes");
+        symlink("/etc", &link).unwrap();
+        let spec = MountSpec {
+            host: link.display().to_string(),
+            container: Some("/home/ai-pod/notes".into()),
+            writable: false,
+        };
+        let w = warn_for_spec(&spec, "/home/ai-pod/notes", dir.path());
+        assert!(
+            w.iter().any(|m| m.contains("resolves via symlinks to")
+                && m.contains("system path")),
+            "expected canonical-tagged system-path warning, got: {:?}",
+            w
+        );
     }
 
     #[test]

--- a/src/mount_cli.rs
+++ b/src/mount_cli.rs
@@ -195,9 +195,159 @@ pub(crate) fn validate_spec(spec: &MountSpec, home_dir: &Path) -> Result<String>
     Ok(target)
 }
 
-pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()> {
+/// Path-specific warnings for `mount add`. Returns a list of human-readable
+/// reasons the mount is risky; an empty vec means "no concerns".
+///
+/// This is the place to teach ai-pod about new risky paths — every entry
+/// becomes an interactive confirmation gate at `mount add` time.
+pub(crate) fn warn_for_spec(spec: &MountSpec, target: &str, home_dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let host = spec.host.as_str();
+
+    // 1. Well-known credential dirs / files under $HOME. These are the
+    //    obvious sources of host-wide compromise if exposed to the agent.
+    let cred_subpaths = [
+        ".ssh",
+        ".aws",
+        ".gnupg",
+        ".config/gh",
+        ".config/gcloud",
+        ".config/git/credentials",
+        ".docker/config.json",
+        ".netrc",
+        ".kube",
+        ".password-store",
+    ];
+    for sub in cred_subpaths {
+        let p = home_dir.join(sub).display().to_string();
+        if host == p || host.starts_with(&format!("{}/", p)) {
+            out.push(format!(
+                "{} holds credentials — the in-container agent would gain full \
+                 access to them, including ability to authenticate as you to \
+                 remote services.",
+                host
+            ));
+            break;
+        }
+    }
+
+    // 2. System / runtime paths on the host. These either expose host-wide
+    //    state or hand the container a root-equivalent control plane.
+    let system_prefixes = [
+        "/etc",
+        "/var/run",
+        "/run",
+        "/proc",
+        "/sys",
+        "/dev",
+        "/boot",
+        "/root",
+        "/var/lib/docker",
+        "/var/lib/containers",
+    ];
+    for sys in system_prefixes {
+        if host == sys || host.starts_with(&format!("{}/", sys)) {
+            out.push(format!(
+                "{} is a host system path — mounting it can leak host secrets \
+                 (e.g. /etc/shadow) or grant container-escape primitives (e.g. \
+                 /var/run/docker.sock, /dev/*, /proc/*).",
+                host
+            ));
+            break;
+        }
+    }
+
+    // 3. ai-pod's own config dir. A writable mount here lets a compromised
+    //    container rewrite the global mount list for the next launch — a
+    //    confused-deputy escalation that compounds with all other risks.
+    let ai_pod = home_dir.join(".ai-pod").display().to_string();
+    if host == ai_pod || host.starts_with(&format!("{}/", ai_pod)) {
+        out.push(format!(
+            "{} is ai-pod's own config directory. Mounting it (especially \
+             writable) lets a container modify the global mount list and \
+             escalate to other host paths on the next launch.",
+            host
+        ));
+    }
+
+    // 4. Container target overrides files that ai-pod itself seeds. The
+    //    settings.json hooks carry $AI_POD_API_KEY; .claude.json holds the
+    //    MCP URL. Replacing either lets a hostile host file hijack the agent.
+    let seeded_files = [
+        "/home/ai-pod/.claude/settings.json",
+        "/home/ai-pod/.claude.json",
+        "/home/ai-pod/.claude/CLAUDE.md",
+        "/home/ai-pod/.gitconfig",
+    ];
+    if seeded_files.contains(&target) {
+        out.push(format!(
+            "Container target {} is seeded by ai-pod (Stop hook, MCP URL, \
+             api-key carrier). Overriding it can hijack the agent's host \
+             call-back or silently disable safety hooks.",
+            target
+        ));
+    }
+
+    // 5. Container target inside a system binary / library tree. The
+    //    runtime-settings Stop hook is a `curl` invocation; replacing the
+    //    binary or libc underneath the agent is full code execution as the
+    //    `ai-pod` user with the api key in env.
+    let bin_prefixes = [
+        "/usr/bin",
+        "/usr/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/bin",
+        "/sbin",
+        "/lib",
+        "/lib64",
+        "/usr/lib",
+        "/usr/lib64",
+        "/boot",
+    ];
+    for bp in bin_prefixes {
+        if target == bp || target.starts_with(&format!("{}/", bp)) {
+            out.push(format!(
+                "Container target {} shadows a system binary/library path. \
+                 The agent will execute whatever host file you mount there.",
+                target
+            ));
+            break;
+        }
+    }
+
+    out
+}
+
+pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool, assume_yes: bool) -> Result<()> {
     let spec = parse_spec(spec_str, writable, &config.home_dir)?;
     let target = crate::container::resolve_container_target(&spec, &config.home_dir)?;
+
+    let warnings = warn_for_spec(&spec, &target, &config.home_dir);
+    if !warnings.is_empty() {
+        eprintln!(
+            "{} this mount is on ai-pod's risky-path warn-list:",
+            "warning:".yellow().bold()
+        );
+        for w in &warnings {
+            eprintln!("  • {}", w);
+        }
+        if !assume_yes {
+            let confirm = dialoguer::Confirm::new()
+                .with_prompt(format!(
+                    "Proceed with mount {} → {} ({})?",
+                    spec.host,
+                    target,
+                    if spec.writable { "rw" } else { "ro" }
+                ))
+                .default(false)
+                .interact()
+                .unwrap_or(false);
+            if !confirm {
+                anyhow::bail!("Mount cancelled by user");
+            }
+        }
+    }
 
     let mut gc = GlobalConfig::load(config);
 
@@ -526,7 +676,7 @@ mod tests {
     fn run_add_rejects_no_container_outside_home() {
         let dir = TempDir::new().unwrap();
         let config = make_config(dir.path());
-        let err = run_add(&config, "/etc/foo", false).unwrap_err();
+        let err = run_add(&config, "/etc/foo", false, true).unwrap_err();
         assert!(err.to_string().contains("outside $HOME"));
     }
 
@@ -536,7 +686,7 @@ mod tests {
         let config = make_config(dir.path());
         std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
-        run_add(&config, "~/.claude/skills", false).unwrap();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1);
         assert_eq!(
@@ -560,7 +710,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let config = make_config(dir.path());
         std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
-        run_add(&config, "~/.claude/skills", false).unwrap();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
 
         run_remove(&config, "~/.claude/skills/").unwrap();
         let gc = GlobalConfig::load(&config);
@@ -573,8 +723,8 @@ mod tests {
         let config = make_config(dir.path());
         std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
-        run_add(&config, "~/.claude/skills", false).unwrap();
-        run_add(&config, "~/.claude/skills", false).unwrap();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1, "duplicate host should not be added");
         assert!(!gc.mounts[0].writable);
@@ -586,8 +736,8 @@ mod tests {
         let config = make_config(dir.path());
         std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
-        run_add(&config, "~/.claude/skills", false).unwrap();
-        let err = run_add(&config, "~/.claude/skills", true).unwrap_err();
+        run_add(&config, "~/.claude/skills", false, true).unwrap();
+        let err = run_add(&config, "~/.claude/skills", true, true).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("already mounted"), "got: {msg}");
         assert!(msg.contains("remove"), "should hint to remove first: {msg}");
@@ -595,6 +745,138 @@ mod tests {
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1);
         assert!(!gc.mounts[0].writable, "stored entry should be unchanged");
+    }
+
+    fn spec(host: &str, container: Option<&str>) -> MountSpec {
+        MountSpec {
+            host: host.to_string(),
+            container: container.map(|c| c.to_string()),
+            writable: false,
+        }
+    }
+
+    #[test]
+    fn warn_flags_ssh_aws_gnupg_under_home() {
+        let home = Path::new("/H");
+        for sub in [".ssh", ".aws", ".gnupg", ".config/gh", ".netrc"] {
+            let host = format!("/H/{}", sub);
+            let target = format!("/home/ai-pod/{}", sub);
+            let w = warn_for_spec(&spec(&host, Some(&target)), &target, home);
+            assert!(!w.is_empty(), "{} should warn", sub);
+            assert!(w.iter().any(|m| m.contains("credentials")), "got {:?}", w);
+        }
+    }
+
+    #[test]
+    fn warn_flags_system_host_paths() {
+        let home = Path::new("/H");
+        for sys in [
+            "/etc/hosts",
+            "/var/run/docker.sock",
+            "/dev/null",
+            "/proc/1",
+            "/sys/kernel",
+            "/root/x",
+        ] {
+            let w = warn_for_spec(&spec(sys, Some("/x")), "/x", home);
+            assert!(!w.is_empty(), "{} should warn", sys);
+            assert!(w.iter().any(|m| m.contains("system path")), "got {:?}", w);
+        }
+    }
+
+    #[test]
+    fn warn_flags_ai_pod_self_mount() {
+        let home = Path::new("/H");
+        let w = warn_for_spec(&spec("/H/.ai-pod", None), "/home/ai-pod/.ai-pod", home);
+        assert!(w.iter().any(|m| m.contains("ai-pod's own")), "got {:?}", w);
+
+        let w = warn_for_spec(
+            &spec("/H/.ai-pod/config.json", Some("/home/ai-pod/cfg")),
+            "/home/ai-pod/cfg",
+            home,
+        );
+        assert!(w.iter().any(|m| m.contains("ai-pod's own")), "got {:?}", w);
+    }
+
+    #[test]
+    fn warn_flags_seeded_target_files() {
+        let home = Path::new("/H");
+        for t in [
+            "/home/ai-pod/.claude/settings.json",
+            "/home/ai-pod/.claude.json",
+            "/home/ai-pod/.claude/CLAUDE.md",
+        ] {
+            let w = warn_for_spec(&spec("/H/x", Some(t)), t, home);
+            assert!(
+                w.iter().any(|m| m.contains("seeded by ai-pod")),
+                "{} should warn, got {:?}",
+                t,
+                w
+            );
+        }
+    }
+
+    #[test]
+    fn warn_flags_binary_shadow_targets() {
+        let home = Path::new("/H");
+        for t in [
+            "/usr/bin/curl",
+            "/bin/sh",
+            "/sbin/init",
+            "/usr/local/bin/foo",
+            "/lib/x86_64-linux-gnu/libc.so.6",
+            "/boot/vmlinuz",
+        ] {
+            let w = warn_for_spec(&spec("/H/x", Some(t)), t, home);
+            assert!(
+                w.iter().any(|m| m.contains("system binary/library")),
+                "{} should warn, got {:?}",
+                t,
+                w
+            );
+        }
+    }
+
+    #[test]
+    fn warn_silent_on_benign_skills_mount() {
+        let home = Path::new("/H");
+        let w = warn_for_spec(
+            &spec("/H/.claude/skills", None),
+            "/home/ai-pod/.claude/skills",
+            home,
+        );
+        assert!(w.is_empty(), "skills mount should be silent, got {:?}", w);
+    }
+
+    #[test]
+    fn run_add_aborts_risky_mount_without_yes() {
+        // Non-interactive: dialoguer::Confirm falls back to its default
+        // (false), so the add must bail rather than succeed silently.
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        let ssh = dir.path().join(".ssh");
+        std::fs::create_dir_all(&ssh).unwrap();
+
+        let err = run_add(&config, &ssh.display().to_string(), false, false).unwrap_err();
+        assert!(
+            err.to_string().contains("cancelled"),
+            "expected cancellation, got: {}",
+            err
+        );
+        let gc = GlobalConfig::load(&config);
+        assert!(gc.mounts.is_empty(), "risky mount must not be stored");
+    }
+
+    #[test]
+    fn run_add_allows_risky_mount_with_yes() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        let ssh = dir.path().join(".ssh");
+        std::fs::create_dir_all(&ssh).unwrap();
+
+        run_add(&config, &ssh.display().to_string(), false, true).unwrap();
+        let gc = GlobalConfig::load(&config);
+        assert_eq!(gc.mounts.len(), 1);
     }
 
     #[test]
@@ -606,8 +888,8 @@ mod tests {
         let a = dir.path().join("a").display().to_string();
         let b = dir.path().join("b").display().to_string();
 
-        run_add(&config, &format!("{}:/home/ai-pod/shared", a), false).unwrap();
-        let err = run_add(&config, &format!("{}:/home/ai-pod/shared", b), false).unwrap_err();
+        run_add(&config, &format!("{}:/home/ai-pod/shared", a), false, true).unwrap();
+        let err = run_add(&config, &format!("{}:/home/ai-pod/shared", b), false, true).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("already used"), "got: {msg}");
 

--- a/src/mount_cli.rs
+++ b/src/mount_cli.rs
@@ -15,33 +15,66 @@ const CONTAINER_HOME: &str = "/home/ai-pod";
 const RESERVED_CONTAINER_PREFIXES: &[&str] =
     &["/proc", "/sys", "/dev", "/etc", "/tmp", "/run", "/var/run"];
 
+/// Exact container paths that ai-pod itself seeds into the home volume
+/// (see `seed_home_volume` in container.rs). Mounting a host path on top of
+/// any of these would silently replace ai-pod's Stop hook / MCP wiring /
+/// opencode plugin and produce a container that looks fine but no longer
+/// communicates with the host. Sub-paths are allowed (e.g.
+/// `/home/ai-pod/.claude/skills` is the advertised use case).
+const SEEDED_CONTAINER_TARGETS: &[&str] = &[
+    "/home/ai-pod/.claude",
+    "/home/ai-pod/.config/opencode/plugins",
+];
+
 /// Parse a user-provided `host[:container]` spec. The host portion is
-/// tilde-expanded against `home_dir`.
+/// tilde-expanded against `home_dir`; both halves are normalized (trailing
+/// slashes trimmed) before validation so dedup and the seeded-path /
+/// reserved-prefix checks can't be bypassed by writing `~/x/` vs `~/x` or
+/// `/home/ai-pod/` vs `/home/ai-pod`.
 pub(crate) fn parse_spec(s: &str, writable: bool, home_dir: &Path) -> Result<MountSpec> {
-    let (host_raw, container) = match s.split_once(':') {
-        Some((h, c)) => (h, Some(c.to_string())),
+    let (host_raw, container_raw) = match s.split_once(':') {
+        Some((h, c)) => (h, Some(c)),
         None => (s, None),
     };
-    let host = expand_tilde(host_raw, home_dir);
-    validate_host_path(&host)?;
-    if let Some(c) = &container {
-        validate_container_path(c)?;
-    }
-    Ok(MountSpec {
+    let host = normalize_host(host_raw, home_dir);
+    let container = container_raw.map(normalize_container);
+    let spec = MountSpec {
         host,
         container,
         writable,
-    })
+    };
+    validate_spec(&spec, home_dir)?;
+    Ok(spec)
 }
 
-pub(crate) fn expand_tilde(s: &str, home_dir: &Path) -> String {
-    if s == "~" {
-        return home_dir.display().to_string();
+/// Expand a leading `~` / `~/` against `home_dir` and strip any trailing
+/// slashes. Used as the single normalization point for both `mount add` and
+/// `mount remove` so they look at exactly the same string.
+pub(crate) fn normalize_host(s: &str, home_dir: &Path) -> String {
+    let expanded = if s == "~" {
+        home_dir.display().to_string()
+    } else if let Some(rest) = s.strip_prefix("~/") {
+        home_dir.join(rest).display().to_string()
+    } else {
+        s.to_string()
+    };
+    trim_trailing_slashes(&expanded)
+}
+
+pub(crate) fn normalize_container(s: &str) -> String {
+    trim_trailing_slashes(s)
+}
+
+fn trim_trailing_slashes(s: &str) -> String {
+    let trimmed = s.trim_end_matches('/');
+    if trimmed.is_empty() {
+        // Preserve "/" so the host-root check in `validate_host_path` can
+        // reject it explicitly rather than producing a misleading
+        // "must not be empty" error.
+        "/".to_string()
+    } else {
+        trimmed.to_string()
     }
-    if let Some(rest) = s.strip_prefix("~/") {
-        return home_dir.join(rest).display().to_string();
-    }
-    s.to_string()
 }
 
 pub(crate) fn validate_host_path(p: &str) -> Result<()> {
@@ -51,6 +84,19 @@ pub(crate) fn validate_host_path(p: &str) -> Result<()> {
     if p.contains('\0') {
         anyhow::bail!("Host path must not contain null bytes");
     }
+    if p.contains(':') {
+        // The `-v` arg uses `:` to separate host:container:opts. A host path
+        // with a `:` either smuggles in mount options (e.g. host
+        // `/x:rw,suid`) or is silently truncated to the first colon, both
+        // of which surprise the user.
+        anyhow::bail!("Host path must not contain ':' (collides with -v separator)");
+    }
+    if p == "/" {
+        anyhow::bail!(
+            "Host path '/' (filesystem root) is not allowed; mounting it would expose \
+             the entire host filesystem to the container"
+        );
+    }
     let path = Path::new(p);
     if !path.is_absolute() {
         anyhow::bail!(
@@ -58,7 +104,10 @@ pub(crate) fn validate_host_path(p: &str) -> Result<()> {
             p
         );
     }
-    if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
         anyhow::bail!("Host path must not contain '..' segments");
     }
     Ok(())
@@ -71,11 +120,17 @@ pub(crate) fn validate_container_path(p: &str) -> Result<()> {
     if p.contains('\0') {
         anyhow::bail!("Container path must not contain null bytes");
     }
+    if p.contains(':') {
+        anyhow::bail!("Container path must not contain ':' (collides with -v separator)");
+    }
     let path = Path::new(p);
     if !path.is_absolute() {
         anyhow::bail!("Container path must be absolute (got {})", p);
     }
-    if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
         anyhow::bail!("Container path must not contain '..' segments");
     }
     if p == "/" {
@@ -95,17 +150,34 @@ pub(crate) fn validate_container_path(p: &str) -> Result<()> {
             anyhow::bail!("Container target {} is reserved", p);
         }
     }
+    for seeded in SEEDED_CONTAINER_TARGETS {
+        if p == *seeded {
+            anyhow::bail!(
+                "Container target {} is seeded by ai-pod and would silently shadow \
+                 the in-container settings. Mount a sub-path instead (e.g. {}/skills).",
+                p,
+                p
+            );
+        }
+    }
     Ok(())
 }
 
-pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()> {
-    let spec = parse_spec(spec_str, writable, &config.home_dir)?;
-
-    // If no explicit container path is given, ensure host is under $HOME so
-    // the launch-time resolver won't fail later.
-    if spec.container.is_none() {
+/// Re-run all validators against a stored `MountSpec`, returning the resolved
+/// container target on success. Called both at `mount add` time (via
+/// [`parse_spec`]) and at every container launch by
+/// `container::build_mount_args` so that a hand-edited `~/.ai-pod/config.json`
+/// can't bypass the security and footgun checks.
+pub(crate) fn validate_spec(spec: &MountSpec, home_dir: &Path) -> Result<String> {
+    validate_host_path(&spec.host)?;
+    if let Some(c) = &spec.container {
+        validate_container_path(c)?;
+    } else {
+        // Auto-mode: host must be under $HOME so the resolver can mirror it.
+        // We check here (in addition to inside `resolve_container_target`)
+        // so the error is actionable at `mount add` time.
         let host = Path::new(&spec.host);
-        if host.strip_prefix(&config.home_dir).is_err() {
+        if host.strip_prefix(home_dir).is_err() {
             anyhow::bail!(
                 "Host path {} is outside $HOME. Supply an explicit container path: \
                  ai-pod mount add {}:<container-path>",
@@ -114,16 +186,58 @@ pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()>
             );
         }
     }
+    let target = crate::container::resolve_container_target(spec, home_dir)?;
+    // Re-validate the *resolved* target so the seeded-path / reserved /
+    // /home/ai-pod-root checks apply to auto-mode mounts too — e.g.
+    // `mount add ~/.claude` resolves to `/home/ai-pod/.claude` and gets
+    // rejected as a seeded prefix.
+    validate_container_path(&target)?;
+    Ok(target)
+}
+
+pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()> {
+    let spec = parse_spec(spec_str, writable, &config.home_dir)?;
+    let target = crate::container::resolve_container_target(&spec, &config.home_dir)?;
 
     let mut gc = GlobalConfig::load(config);
-    if !gc.add(spec.clone()) {
+
+    if let Some(existing) = gc.mounts.iter().find(|m| m.host == spec.host) {
+        if existing.writable != spec.writable {
+            anyhow::bail!(
+                "{} is already mounted as {}. Run `ai-pod mount remove {}` first, \
+                 then re-add{}.",
+                spec.host,
+                if existing.writable { "rw" } else { "ro" },
+                spec.host,
+                if spec.writable { " with --writable" } else { "" }
+            );
+        }
         println!("{} {}", "Already mounted:".yellow(), spec.host);
         return Ok(());
     }
+
+    for existing in &gc.mounts {
+        let existing_target = match crate::container::resolve_container_target(
+            existing,
+            &config.home_dir,
+        ) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if existing_target == target {
+            anyhow::bail!(
+                "Container target {} is already used by mount {}; pick a different \
+                 container path with `ai-pod mount add {}:<other-path>`.",
+                target,
+                existing.host,
+                spec.host
+            );
+        }
+    }
+
+    gc.add(spec.clone());
     gc.save(config)?;
 
-    let target = crate::container::resolve_container_target(&spec, &config.home_dir)
-        .unwrap_or_else(|_| "(invalid)".to_string());
     println!(
         "{} {} → {} ({})",
         "Mounted:".green().bold(),
@@ -132,19 +246,19 @@ pub fn run_add(config: &AppConfig, spec_str: &str, writable: bool) -> Result<()>
         if spec.writable { "rw" } else { "ro" }
     );
 
-    warn_if_unreadable(&spec)?;
+    warn_if_unreadable(&spec);
     Ok(())
 }
 
 pub fn run_remove(config: &AppConfig, host: &str) -> Result<()> {
-    let expanded = expand_tilde(host, &config.home_dir);
+    let normalized = normalize_host(host, &config.home_dir);
     let mut gc = GlobalConfig::load(config);
-    if !gc.remove(&expanded) {
-        println!("{} {}", "Not mounted:".yellow(), expanded);
+    if !gc.remove(&normalized) {
+        println!("{} {}", "Not mounted:".yellow(), normalized);
         return Ok(());
     }
     gc.save(config)?;
-    println!("{} {}", "Unmounted:".green().bold(), expanded);
+    println!("{} {}", "Unmounted:".green().bold(), normalized);
     Ok(())
 }
 
@@ -162,7 +276,7 @@ pub fn run_list(config: &AppConfig) -> Result<()> {
         let target = crate::container::resolve_container_target(m, &config.home_dir)
             .unwrap_or_else(|_| "(invalid)".to_string());
         let mode = if m.writable { "rw" } else { "ro" };
-        let exists = if Path::new(&m.host).exists() {
+        let exists = if Path::new(&m.host).symlink_metadata().is_ok() {
             ""
         } else {
             "  (missing — will be skipped at launch)"
@@ -172,21 +286,21 @@ pub fn run_list(config: &AppConfig) -> Result<()> {
     Ok(())
 }
 
-/// One-line warning for `mount add` when the host file is mode-restricted in a
-/// way that the in-container `ai-pod` user is unlikely to be able to read it.
-/// Best-effort; silent on any error.
-fn warn_if_unreadable(spec: &MountSpec) -> Result<()> {
+/// One-line warning for `mount add` when the host file is mode-restricted in
+/// a way that the in-container `ai-pod` user is unlikely to be able to read
+/// it. Best-effort; silent on any error.
+fn warn_if_unreadable(spec: &MountSpec) {
     let path = Path::new(&spec.host);
     let meta = match std::fs::metadata(path) {
         Ok(m) => m,
-        Err(_) => return Ok(()),
+        Err(_) => return,
     };
     if !meta.is_file() {
-        return Ok(());
+        return;
     }
     let mode = meta.permissions().mode() & 0o777;
     if mode & 0o004 != 0 {
-        return Ok(());
+        return;
     }
     eprintln!(
         "{} {} has mode {:o}; the container user may not be able to read it under \
@@ -196,7 +310,6 @@ fn warn_if_unreadable(spec: &MountSpec) -> Result<()> {
         mode,
         spec.host
     );
-    Ok(())
 }
 
 #[cfg(test)]
@@ -204,11 +317,23 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn make_config(home: &Path) -> AppConfig {
+        let config_dir = home.join(".ai-pod");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        AppConfig {
+            runtime_settings: config_dir.join("runtime-settings.json"),
+            config_dir,
+            home_dir: home.to_path_buf(),
+        }
+    }
+
     #[test]
     fn parse_spec_host_only() {
         let dir = TempDir::new().unwrap();
-        let spec = parse_spec("/abs/path", false, dir.path()).unwrap();
-        assert_eq!(spec.host, "/abs/path");
+        std::fs::create_dir_all(dir.path().join("abs/path")).unwrap();
+        let host = dir.path().join("abs/path");
+        let spec = parse_spec(&host.display().to_string(), false, dir.path()).unwrap();
+        assert_eq!(spec.host, host.display().to_string());
         assert_eq!(spec.container, None);
         assert!(!spec.writable);
     }
@@ -263,7 +388,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         for r in ["/proc", "/proc/sys", "/sys", "/dev/null", "/etc/passwd"] {
             let err = parse_spec(&format!("/host:{}", r), false, dir.path()).unwrap_err();
-            assert!(err.to_string().contains("reserved"), "target {} should be reserved", r);
+            assert!(
+                err.to_string().contains("reserved"),
+                "target {} should be reserved",
+                r
+            );
         }
     }
 
@@ -282,25 +411,121 @@ mod tests {
     }
 
     #[test]
-    fn expand_tilde_only_at_start() {
+    fn parse_spec_rejects_filesystem_root_host() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/:/host", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("filesystem root"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_filesystem_root_host_alone() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("filesystem root"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_colon_smuggling_in_container() {
+        // `split_once(':')` puts everything after the first colon into the
+        // container portion, so this would otherwise smuggle `rw,suid` into
+        // the podman -v opts.
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/tmp/x:/foo:rw,suid", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("':'"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_normalizes_trailing_slash_in_host() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let spec = parse_spec("~/x/", false, home).unwrap();
+        assert_eq!(spec.host, home.join("x").display().to_string());
+        assert!(!spec.host.ends_with('/'));
+    }
+
+    #[test]
+    fn parse_spec_normalizes_trailing_slash_in_container() {
+        let dir = TempDir::new().unwrap();
+        let spec = parse_spec("/host:/foo/bar/", false, dir.path()).unwrap();
+        assert_eq!(spec.container.as_deref(), Some("/foo/bar"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_trailing_slash_bypass_of_container_home() {
+        let dir = TempDir::new().unwrap();
+        // Without normalization, "/home/ai-pod/" would slip past the
+        // `p == CONTAINER_HOME` exact-match check.
+        let err = parse_spec("/host:/home/ai-pod/", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("home volume"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_trailing_slash_bypass_of_app() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/host:/app/", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("/app"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_trailing_slash_bypass_of_reserved() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/host:/etc/", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("reserved"));
+    }
+
+    #[test]
+    fn parse_spec_rejects_seeded_dot_claude() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("/host:/home/ai-pod/.claude", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("seeded"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_seeded_opencode_plugins() {
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec(
+            "/host:/home/ai-pod/.config/opencode/plugins",
+            false,
+            dir.path(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("seeded"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_auto_mode_dot_claude() {
+        // `~/.claude` in auto-mode resolves to `/home/ai-pod/.claude`, which
+        // is a seeded prefix. Without re-validating the resolved target,
+        // this would silently shadow the Stop hook + MCP wiring.
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        let err = parse_spec("~/.claude", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("seeded"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_spec_rejects_auto_mode_home_root() {
+        // `mount add ~` resolves to `/home/ai-pod`, shadowing the home volume.
+        let dir = TempDir::new().unwrap();
+        let err = parse_spec("~", false, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("home volume"), "got: {err}");
+    }
+
+    #[test]
+    fn normalize_host_only_at_start() {
         let home = Path::new("/H");
-        assert_eq!(expand_tilde("~", home), "/H");
-        assert_eq!(expand_tilde("~/foo", home), "/H/foo");
-        assert_eq!(expand_tilde("/abs/~/foo", home), "/abs/~/foo");
-        assert_eq!(expand_tilde("/abs", home), "/abs");
+        assert_eq!(normalize_host("~", home), "/H");
+        assert_eq!(normalize_host("~/foo", home), "/H/foo");
+        assert_eq!(normalize_host("~/foo/", home), "/H/foo");
+        assert_eq!(normalize_host("/abs/~/foo", home), "/abs/~/foo");
+        assert_eq!(normalize_host("/abs", home), "/abs");
+        assert_eq!(normalize_host("/", home), "/");
     }
 
     #[test]
     fn run_add_rejects_no_container_outside_home() {
         let dir = TempDir::new().unwrap();
-        let home = dir.path().to_path_buf();
-        let config_dir = home.join(".ai-pod");
-        std::fs::create_dir_all(&config_dir).unwrap();
-        let config = AppConfig {
-            runtime_settings: config_dir.join("runtime-settings.json"),
-            config_dir,
-            home_dir: home,
-        };
+        let config = make_config(dir.path());
         let err = run_add(&config, "/etc/foo", false).unwrap_err();
         assert!(err.to_string().contains("outside $HOME"));
     }
@@ -308,27 +533,20 @@ mod tests {
     #[test]
     fn run_add_and_remove_round_trip() {
         let dir = TempDir::new().unwrap();
-        let home = dir.path().to_path_buf();
-        let config_dir = home.join(".ai-pod");
-        std::fs::create_dir_all(&config_dir).unwrap();
-        let config = AppConfig {
-            runtime_settings: config_dir.join("runtime-settings.json"),
-            config_dir,
-            home_dir: home.clone(),
-        };
-        std::fs::create_dir_all(home.join(".claude/skills")).unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
         run_add(&config, "~/.claude/skills", false).unwrap();
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1);
         assert_eq!(
             gc.mounts[0].host,
-            home.join(".claude/skills").display().to_string()
+            dir.path().join(".claude/skills").display().to_string()
         );
 
         run_remove(
             &config,
-            &home.join(".claude/skills").display().to_string(),
+            &dir.path().join(".claude/skills").display().to_string(),
         )
         .unwrap();
         let gc = GlobalConfig::load(&config);
@@ -336,22 +554,64 @@ mod tests {
     }
 
     #[test]
-    fn run_add_dedups_by_host() {
+    fn run_remove_normalizes_trailing_slash() {
+        // Symmetric with parse_spec normalization: a user who types
+        // `~/x/` for `mount remove` should find the entry stored as `~/x`.
         let dir = TempDir::new().unwrap();
-        let home = dir.path().to_path_buf();
-        let config_dir = home.join(".ai-pod");
-        std::fs::create_dir_all(&config_dir).unwrap();
-        let config = AppConfig {
-            runtime_settings: config_dir.join("runtime-settings.json"),
-            config_dir,
-            home_dir: home.clone(),
-        };
-        std::fs::create_dir_all(home.join(".claude/skills")).unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
+        run_add(&config, "~/.claude/skills", false).unwrap();
+
+        run_remove(&config, "~/.claude/skills/").unwrap();
+        let gc = GlobalConfig::load(&config);
+        assert!(gc.mounts.is_empty(), "remove should find the entry");
+    }
+
+    #[test]
+    fn run_add_dedups_by_host_when_writable_matches() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
 
         run_add(&config, "~/.claude/skills", false).unwrap();
-        run_add(&config, "~/.claude/skills", true).unwrap();
+        run_add(&config, "~/.claude/skills", false).unwrap();
         let gc = GlobalConfig::load(&config);
         assert_eq!(gc.mounts.len(), 1, "duplicate host should not be added");
-        assert!(!gc.mounts[0].writable, "first add wins");
+        assert!(!gc.mounts[0].writable);
+    }
+
+    #[test]
+    fn run_add_errors_on_writable_mismatch() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
+
+        run_add(&config, "~/.claude/skills", false).unwrap();
+        let err = run_add(&config, "~/.claude/skills", true).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("already mounted"), "got: {msg}");
+        assert!(msg.contains("remove"), "should hint to remove first: {msg}");
+
+        let gc = GlobalConfig::load(&config);
+        assert_eq!(gc.mounts.len(), 1);
+        assert!(!gc.mounts[0].writable, "stored entry should be unchanged");
+    }
+
+    #[test]
+    fn run_add_rejects_colliding_container_target() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path());
+        std::fs::create_dir_all(dir.path().join("a")).unwrap();
+        std::fs::create_dir_all(dir.path().join("b")).unwrap();
+        let a = dir.path().join("a").display().to_string();
+        let b = dir.path().join("b").display().to_string();
+
+        run_add(&config, &format!("{}:/home/ai-pod/shared", a), false).unwrap();
+        let err = run_add(&config, &format!("{}:/home/ai-pod/shared", b), false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("already used"), "got: {msg}");
+
+        let gc = GlobalConfig::load(&config);
+        assert_eq!(gc.mounts.len(), 1, "colliding mount should not be stored");
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -195,7 +195,9 @@ async fn reload_handler(State(state): State<AppState>) -> &'static str {
                 Some(s) => s.to_string(),
                 None => continue,
             };
-            if stem == "server" {
+            // "server" = the shared server state, "config" = the global
+            // GlobalConfig (mounts). Neither is a per-project state file.
+            if stem == "server" || stem == "config" {
                 continue;
             }
             let ps = ProjectState::load(&path);
@@ -226,7 +228,9 @@ pub async fn run_server(port: u16, config: AppConfig, rt: ContainerRuntime) -> a
                 Some(s) => s.to_string(),
                 None => continue,
             };
-            if stem == "server" {
+            // "server" = the shared server state, "config" = the global
+            // GlobalConfig (mounts). Neither is a per-project state file.
+            if stem == "server" || stem == "config" {
                 continue;
             }
             let state = ProjectState::load(&path);


### PR DESCRIPTION
Addresses the 13 must-fix + nice-to-have findings from the two reviews on #94. Merge into `claude/issue-91-planning-bji4d` so they ship with the original `ai-pod mount` PR.

## Security

- **Reject `/` as host path** — `ai-pod mount add /:/host` previously mounted the entire filesystem into every container ([review](https://github.com/mismosmi/ai-pod/pull/94#discussion_r3294718016)).
- **Reject `:` in host and container paths** — `ai-pod mount add /tmp/x:/foo:rw,suid` smuggled `rw,suid` past the read-only-by-default policy because the second `:` was treated as part of the container path ([review](https://github.com/mismosmi/ai-pod/pull/94#discussion_r3294721004)).

## Footguns

- **Reject `ai-pod mount add ~`** — `strip_prefix` on `host == home_dir` returned an empty path, producing the target `/home/ai-pod/` and shadowing the seeded home volume ([review](https://github.com/mismosmi/ai-pod/pull/94#discussion_r3294718768)). Fixed both in `resolve_container_target` and via the re-validation path.
- **Reject `~/.claude` and `~/.config/opencode/plugins`** as auto-mode targets — they would silently shadow `seed_home_volume`'s `.claude/settings.json` (Stop hook + `bypassPermissions`) and the opencode plugin ([review](https://github.com/mismosmi/ai-pod/pull/94#discussion_r3294720129)). New `SEEDED_CONTAINER_TARGETS` list; the advertised `~/.claude/skills` sub-path still works.
- **Trailing-slash normalization** — single normalization point in `normalize_host` / `normalize_container`. `/home/ai-pod/`, `/app/`, `/etc/` no longer bypass the exact-match checks; `mount remove ~/x/` finds an entry stored as `~/x` ([review](https://github.com/mismosmi/ai-pod/pull/94#discussion_r3294722332) + claude bot finding).
- **`mount add <existing> --writable` is an explicit error** instead of a silent no-op; hints the user to `mount remove` first ([review](https://github.com/mismosmi/ai-pod/pull/94#discussion_r3294722810)).
- **Reject colliding container targets** — two mounts can no longer silently shadow each other.

## Stored-state robustness

- **Re-validate every stored `MountSpec` at launch** — `build_mount_args` runs `validate_spec` against the *current* `$HOME` + rule set. Failures warn-and-skip ([review](https://github.com/mismosmi/ai-pod/pull/94#discussion_r3294721591)).
- **Resolve failure no longer bricks every launch** — was `?`, now warn-and-skip to match the missing-host policy right above ([review](https://github.com/mismosmi/ai-pod/pull/94#discussion_r3294717241)). Fixes the cross-machine config-sync case.
- **Dangling symlinks count as present** — switched `exists()` (follows symlinks) to `symlink_metadata().is_err()`, matching `MountSpec`'s "symlinks intentionally not resolved" doc (claude bot finding).
- **`GlobalConfig::save` re-applies 0o600 after rename** — `.mode(0o600)` only takes effect on `O_CREAT`, so a stale `.tmp` from a crashed earlier run kept its old mode through `truncate` (claude bot finding).

## Out-of-diff

- **`src/server/mod.rs` project scan skips `config.json`** — defensive. Today the empty-field filter happens to drop it, but a future `#[serde(default)]` on a `ProjectState` field would let it register as a fake project (review summary).

## Misc cleanup

- `warn_if_unreadable` drops its `Result<()>` return — function only `eprintln`s and never propagated errors (claude bot finding).

## Out of scope (not addressed)

- **Dynamic column widths in `run_list`** — cosmetic only; the existing `{:<50} → {:<40}` works for typical paths.

## Test plan

- [x] `cargo build` clean, no new warnings
- [x] `cargo clippy --all-targets` — no new findings in changed files
- [x] `cargo test` — 159/159 lib (up from 139), 5/5 bin, 12/12 e2e, 1/1 rate-limit
- [x] 20 new unit tests cover: filesystem-root host, colon smuggling, trailing-slash bypass on `/home/ai-pod` / `/app` / `/etc`, seeded `.claude` / `opencode/plugins` (both explicit and auto-mode), `mount add ~` rejection, container-target collision, `--writable` mismatch, `mount remove` with trailing slash, `build_mount_args` warn-skip on outside-`$HOME` and invalid stored specs, dangling symlinks, `GlobalConfig::save` over a stale 0o644 tmp.
- [ ] End-to-end: launch a container with a stored mount across a `$HOME` mismatch (deferred — same as PR #94's open E2E item)

---
_Generated by [Claude Code](https://claude.ai/code/session_014n2g3i7fXtypsZXKrhPijJ)_