### PR TITLE
feat: ai-pod manage TUI for agent orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "notify-rust",
+ "portable-pty",
  "ratatui",
  "regex",
  "reqwest",
@@ -40,6 +41,7 @@ dependencies = [
  "tower",
  "tower_governor",
  "uuid",
+ "vt100",
  "walkdir",
 ]
 
@@ -104,6 +106,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
@@ -451,6 +459,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -516,7 +530,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -811,7 +825,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -843,6 +857,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -902,7 +922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1748,7 +1768,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -1805,13 +1825,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -2157,6 +2189,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,7 +2292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -2280,7 +2333,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -2576,7 +2629,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2633,7 +2686,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2797,6 +2850,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,6 +2880,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -3023,7 +3097,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3065,7 +3139,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -3448,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -3506,6 +3580,27 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "vtparse"
@@ -3784,7 +3879,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4026,6 +4121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tower_governor",
+ "unicode-width",
  "uuid",
  "vt100",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ ratatui = "0.30"
 crossterm = "0.29"
 vt100 = "0.16"
 portable-pty = "0.9"
+unicode-width = "0.2"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ regex = "1"
 tower_governor = "0.8"
 ratatui = "0.30"
 crossterm = "0.29"
+vt100 = "0.16"
+portable-pty = "0.9"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -143,6 +143,9 @@ pub enum Command {
 
     /// Update ai-pod to the latest release
     Update,
+
+    /// Open a TUI to manage all running ai-pod agents on this host.
+    Manage,
 }
 
 #[derive(Subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,16 @@ impl AppConfig {
         self.config_dir.join(format!("{}.json", hash))
     }
 
+    /// Directory that stores per-session agent status files written by Claude
+    /// Stop/Notification hooks (and the OpenCode plugin). Each session id maps
+    /// to a single JSON file `{session_id}.json` inside this directory.
+    pub fn agents_dir(&self) -> PathBuf {
+        let base = dirs::data_local_dir()
+            .or_else(dirs::data_dir)
+            .unwrap_or_else(|| self.home_dir.join(".local").join("share"));
+        base.join("ai-pod").join("agents")
+    }
+
     /// Returns path to the shared server state file: ~/.ai-pod/server.json
     pub fn server_state_file(&self) -> PathBuf {
         self.config_dir.join("server.json")

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,19 @@ impl AppConfig {
 
     pub fn init(&self) -> Result<()> {
         std::fs::create_dir_all(&self.config_dir).context("Failed to create ~/.ai-pod/")?;
+        // Always (re)write the bundled OpenCode plugin so updates to the
+        // template propagate without the user having to delete the old
+        // file by hand. This is the host-side copy; the per-volume copy
+        // is refreshed during seed_home_volume on container init/rebuild.
+        let plugin_path = self.config_dir.join("opencode-plugin.js");
+        let bundled = include_str!("../templates/opencode-plugin.js");
+        if std::fs::read_to_string(&plugin_path)
+            .map(|s| s != bundled)
+            .unwrap_or(true)
+        {
+            std::fs::write(&plugin_path, bundled)
+                .context("Failed to write opencode-plugin.js")?;
+        }
         Ok(())
     }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -284,7 +284,12 @@ fn generate_runtime_settings(config: &AppConfig) -> Result<()> {
 
     let hooks = obj.entry("hooks").or_insert_with(|| serde_json::json!({}));
     let hooks_obj = hooks.as_object_mut().context("hooks is not an object")?;
-    hooks_obj.insert("Stop".to_string(), stop_hook);
+    hooks_obj.insert("Stop".to_string(), stop_hook.clone());
+    // SubagentStop fires when a subagent finishes — including when the
+    // user interrupts a subagent's turn. Treat it the same as Stop so
+    // rows recover from "Working..." after cancellations that don't
+    // bubble up as a top-level Stop.
+    hooks_obj.insert("SubagentStop".to_string(), stop_hook);
     hooks_obj.insert("Notification".to_string(), notification_hook);
     hooks_obj.insert("UserPromptSubmit".to_string(), prompt_submit_hook);
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -17,6 +17,70 @@ use crate::workspace::{
 /// runtime does not need to probe the image.
 const CONTAINER_HOME: &str = "/home/ai-pod";
 
+/// One row from `podman ps -a --filter label=managed-by=ai-pod` enriched
+/// with the labels we set on launch. `workspace_path` and `session_id` are
+/// `None` for legacy containers launched before those labels were added.
+#[derive(Debug, Clone)]
+pub struct ManagedContainer {
+    pub name: String,
+    pub status: String,
+    pub state: String,
+    pub created_at: String,
+    pub workspace_path: Option<String>,
+    pub session_id: Option<String>,
+}
+
+/// List every container labelled `managed-by=ai-pod` on the host, including
+/// stopped ones. Returns structured rows so callers can pick out the workspace
+/// path or session id without re-shelling out.
+pub fn list_managed_containers(rt: &ContainerRuntime) -> Result<Vec<ManagedContainer>> {
+    let format = "{{.Names}}\t{{.Status}}\t{{.State}}\t{{.CreatedAt}}\t{{.Label \"workspace-path\"}}\t{{.Label \"ai-pod-session\"}}";
+    let output = rt
+        .command()
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "label=managed-by=ai-pod",
+            "--format",
+            format,
+        ])
+        .output()
+        .context("Failed to list ai-pod containers")?;
+    let mut rows = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.split('\t').collect();
+        let name = parts.first().copied().unwrap_or("").to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let status = parts.get(1).copied().unwrap_or("").to_string();
+        let state = parts.get(2).copied().unwrap_or("").to_string();
+        let created_at = parts.get(3).copied().unwrap_or("").to_string();
+        let workspace_path = parts
+            .get(4)
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty() && s != "<no value>");
+        let session_id = parts
+            .get(5)
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty() && s != "<no value>")
+            .or_else(|| crate::workspace::session_id_from_container_name(&name));
+        rows.push(ManagedContainer {
+            name,
+            status,
+            state,
+            created_at,
+            workspace_path,
+            session_id,
+        });
+    }
+    Ok(rows)
+}
+
 pub fn containers_for_prefix(
     rt: &ContainerRuntime,
     prefix: &str,
@@ -173,20 +237,33 @@ fn generate_runtime_settings(config: &AppConfig) -> Result<()> {
         )
     };
 
+    // Mirror notify_user to the new /agent_status endpoint so the manage TUI
+    // sees the same transitions (Idle on Stop, AwaitingInput on Notification).
+    // The Notification hook receives JSON on stdin; pull `.message` out with
+    // jq if present, falling back to a hard-coded label so the hook still
+    // works in containers without jq installed.
+    let agent_status_curl = |status: &str, fallback_line: &str| {
+        format!(
+            "MSG=$(jq -r .message 2>/dev/null || true); MSG=${{MSG:-{fallback}}}; curl -fsS -X POST -H \"X-Api-Key: $AI_POD_API_KEY\" -H 'Content-Type: application/json' -d \"$(printf '{{\"project_id\":\"%s\",\"session_id\":\"%s\",\"status\":\"%s\",\"status_line\":\"%s\"}}' \"$AI_POD_PROJECT_ID\" \"$AI_POD_SESSION_ID\" \"{status}\" \"$MSG\")\" \"$AI_POD_SERVER_URL/agent_status\" >/dev/null || true",
+            status = status,
+            fallback = fallback_line,
+        )
+    };
+
     let stop_hook = serde_json::json!([{
         "matcher": "*",
-        "hooks": [{
-            "type": "command",
-            "command": notify_curl("Task completed"),
-        }]
+        "hooks": [
+            { "type": "command", "command": notify_curl("Task completed") },
+            { "type": "command", "command": agent_status_curl("Idle", "Task completed") },
+        ]
     }]);
 
     let permission_hook = serde_json::json!([{
         "matcher": "*",
-        "hooks": [{
-            "type": "command",
-            "command": notify_curl("Claude needs your approval"),
-        }]
+        "hooks": [
+            { "type": "command", "command": notify_curl("Claude needs your approval") },
+            { "type": "command", "command": agent_status_curl("AwaitingInput", "Claude needs your approval") },
+        ]
     }]);
 
     let obj = settings
@@ -628,11 +705,17 @@ pub fn launch_container(
 
     let mut run_cmd = rt.command();
     run_cmd.args(["run", "--rm", "-it"]);
+    let workspace_label = format!("workspace-path={}", workspace_str);
+    let session_label = format!("ai-pod-session={}", session_id);
     run_cmd.args([
         "--name",
         &container_name,
         "--label",
         "managed-by=ai-pod",
+        "--label",
+        &workspace_label,
+        "--label",
+        &session_label,
         "--network",
         &service_net,
         "-v",
@@ -673,6 +756,115 @@ pub fn launch_container(
     let _ = run_status;
 
     Ok(())
+}
+
+/// Start a new ai-pod session in detached mode and return its container name.
+/// Used by the `ai-pod manage` TUI so the new session does not take over the
+/// caller's tty; the TUI attaches to it through `podman attach` like any
+/// pre-existing session.
+pub fn start_container_detached(
+    rt: &ContainerRuntime,
+    config: &AppConfig,
+    workspace: &Path,
+    image: &str,
+    project_id: &str,
+    api_key: &str,
+) -> Result<String> {
+    let prefix = container_prefix(workspace);
+    let volume_name = gen_volume_name(workspace);
+    let workspace_str = workspace.to_string_lossy();
+
+    if !volume_exists(rt, &volume_name)? {
+        init_home_volume(
+            rt,
+            config,
+            &volume_name,
+            &prefix,
+            image,
+            project_id,
+            api_key,
+        )?;
+    }
+
+    let session_id = new_session_id();
+    let container_name = container_name_for(workspace, &session_id);
+
+    refresh_claude_mcp_in_volume(
+        rt,
+        config,
+        &volume_name,
+        &prefix,
+        image,
+        &rt.server_url(),
+        api_key,
+        &session_id,
+    )?;
+
+    let add_host = rt.add_host_arg();
+    let host_gw_env = format!("HOST_GATEWAY={}", rt.host_gateway());
+    let server_url_env = format!("AI_POD_SERVER_URL={}", rt.server_url());
+    let opencode_config_env = format!(
+        "OPENCODE_CONFIG_CONTENT={}",
+        opencode_config_content(&rt.server_url(), api_key, &session_id)
+    );
+
+    let project_state = load_project_state(config, workspace);
+    let mask_args = mask_mount_args(rt, workspace, image, &project_state.masked_directories)?;
+    let service_net = crate::service::ensure_service_network(rt, workspace)?;
+
+    let workspace_label = format!("workspace-path={}", workspace_str);
+    let session_label = format!("ai-pod-session={}", session_id);
+    let mut run_cmd = rt.command();
+    // -d for detached + -it to allocate a tty + keep stdin open so `podman
+    // attach` can drive the interactive agent later.
+    run_cmd.args(["run", "--rm", "-d", "-it"]);
+    run_cmd.args([
+        "--name",
+        &container_name,
+        "--label",
+        "managed-by=ai-pod",
+        "--label",
+        &workspace_label,
+        "--label",
+        &session_label,
+        "--network",
+        &service_net,
+        "-v",
+        &format!("{}:{}:z", volume_name, CONTAINER_HOME),
+        "-v",
+        &format!("{}:/app:Z", workspace_str),
+    ]);
+    for arg in &mask_args {
+        run_cmd.arg(arg);
+    }
+    run_cmd.args([
+        &add_host,
+        "-e",
+        &host_gw_env,
+        "-e",
+        &format!("AI_POD_PROJECT_ID={}", project_id),
+        "-e",
+        &format!("AI_POD_API_KEY={}", api_key),
+        "-e",
+        &format!("AI_POD_SESSION_ID={}", session_id),
+        "-e",
+        &server_url_env,
+        "-e",
+        &opencode_config_env,
+    ]);
+    run_cmd.arg(image);
+
+    let output = run_cmd
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .context("Failed to start container")?;
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("{} run failed: {}", rt.cmd(), err.trim());
+    }
+
+    Ok(container_name)
 }
 
 pub fn run_in_container(
@@ -737,6 +929,10 @@ pub fn run_in_container(
     run_args.extend_from_slice(&[
         "--label".into(),
         "managed-by=ai-pod".into(),
+        "--label".into(),
+        format!("workspace-path={}", workspace_str),
+        "--label".into(),
+        format!("ai-pod-session={}", session_id),
         "--network".into(),
         service_net,
         "-v".into(),

--- a/src/container.rs
+++ b/src/container.rs
@@ -239,14 +239,14 @@ fn generate_runtime_settings(config: &AppConfig) -> Result<()> {
 
     // Mirror notify_user to the new /agent_status endpoint so the manage TUI
     // sees the same transitions (Idle on Stop, AwaitingInput on Notification).
-    // The Notification hook receives JSON on stdin; pull `.message` out with
-    // jq if present, falling back to a hard-coded label so the hook still
-    // works in containers without jq installed.
-    let agent_status_curl = |status: &str, fallback_line: &str| {
+    // Uses the same single-quote-concat style as notify_curl — no jq, no
+    // printf — so it parses on /bin/sh inside minimal containers and doesn't
+    // contend with notify_curl for stdin.
+    let agent_status_curl = |status: &str, line: &str| {
         format!(
-            "MSG=$(jq -r .message 2>/dev/null || true); MSG=${{MSG:-{fallback}}}; curl -fsS -X POST -H \"X-Api-Key: $AI_POD_API_KEY\" -H 'Content-Type: application/json' -d \"$(printf '{{\"project_id\":\"%s\",\"session_id\":\"%s\",\"status\":\"%s\",\"status_line\":\"%s\"}}' \"$AI_POD_PROJECT_ID\" \"$AI_POD_SESSION_ID\" \"{status}\" \"$MSG\")\" \"$AI_POD_SERVER_URL/agent_status\" >/dev/null || true",
+            "curl -fsS -X POST -H \"X-Api-Key: $AI_POD_API_KEY\" -H 'Content-Type: application/json' -d '{{\"project_id\":\"'\"$AI_POD_PROJECT_ID\"'\",\"session_id\":\"'\"$AI_POD_SESSION_ID\"'\",\"status\":\"{status}\",\"status_line\":\"{line}\"}}' \"$AI_POD_SERVER_URL/agent_status\" >/dev/null || true",
             status = status,
-            fallback = fallback_line,
+            line = line,
         )
     };
 
@@ -258,7 +258,9 @@ fn generate_runtime_settings(config: &AppConfig) -> Result<()> {
         ]
     }]);
 
-    let permission_hook = serde_json::json!([{
+    // Claude Code fires `Notification` (not `PermissionRequest`) when it
+    // needs the user — permission prompts, idle timeouts, etc.
+    let notification_hook = serde_json::json!([{
         "matcher": "*",
         "hooks": [
             { "type": "command", "command": notify_curl("Claude needs your approval") },
@@ -273,7 +275,7 @@ fn generate_runtime_settings(config: &AppConfig) -> Result<()> {
     let hooks = obj.entry("hooks").or_insert_with(|| serde_json::json!({}));
     let hooks_obj = hooks.as_object_mut().context("hooks is not an object")?;
     hooks_obj.insert("Stop".to_string(), stop_hook);
-    hooks_obj.insert("PermissionRequest".to_string(), permission_hook);
+    hooks_obj.insert("Notification".to_string(), notification_hook);
 
     // Set default permission mode — no per-tool prompts in TUI
     let permissions = obj

--- a/src/container.rs
+++ b/src/container.rs
@@ -268,6 +268,16 @@ fn generate_runtime_settings(config: &AppConfig) -> Result<()> {
         ]
     }]);
 
+    // User just submitted a prompt → the agent is working. Without this
+    // hook the row stays stuck on the previous turn's "Task completed"
+    // until the next Stop fires.
+    let prompt_submit_hook = serde_json::json!([{
+        "matcher": "*",
+        "hooks": [
+            { "type": "command", "command": agent_status_curl("Running", "Working...") },
+        ]
+    }]);
+
     let obj = settings
         .as_object_mut()
         .context("settings.json is not an object")?;
@@ -276,6 +286,7 @@ fn generate_runtime_settings(config: &AppConfig) -> Result<()> {
     let hooks_obj = hooks.as_object_mut().context("hooks is not an object")?;
     hooks_obj.insert("Stop".to_string(), stop_hook);
     hooks_obj.insert("Notification".to_string(), notification_hook);
+    hooks_obj.insert("UserPromptSubmit".to_string(), prompt_submit_hook);
 
     // Set default permission mode — no per-tool prompts in TUI
     let permissions = obj
@@ -764,6 +775,9 @@ pub fn launch_container(
 /// Used by the `ai-pod manage` TUI so the new session does not take over the
 /// caller's tty; the TUI attaches to it through `podman attach` like any
 /// pre-existing session.
+// `cmd_override`: optional override for the container's CMD. `None` uses
+// the Dockerfile's default (`claude` / `opencode`). When `Some`, the first
+// element is set as `--entrypoint`, the rest are passed as trailing args.
 pub fn start_container_detached(
     rt: &ContainerRuntime,
     config: &AppConfig,
@@ -771,6 +785,7 @@ pub fn start_container_detached(
     image: &str,
     project_id: &str,
     api_key: &str,
+    cmd_override: Option<&[String]>,
 ) -> Result<String> {
     let prefix = container_prefix(workspace);
     let volume_name = gen_volume_name(workspace);
@@ -854,7 +869,18 @@ pub fn start_container_detached(
         "-e",
         &opencode_config_env,
     ]);
-    run_cmd.arg(image);
+
+    // Build the rest of the run command, splicing in --entrypoint/args
+    // around `image` when the caller supplied an override.
+    if let Some(parts) = cmd_override.filter(|p| !p.is_empty()) {
+        run_cmd.args(["--entrypoint", &parts[0]]);
+        run_cmd.arg(image);
+        for arg in &parts[1..] {
+            run_cmd.arg(arg);
+        }
+    } else {
+        run_cmd.arg(image);
+    }
 
     let output = run_cmd
         .stdout(Stdio::null())

--- a/src/image.rs
+++ b/src/image.rs
@@ -7,6 +7,79 @@ use crate::runtime::ContainerRuntime;
 
 pub const DOCKERFILE_NAME: &str = "ai-pod.Dockerfile";
 
+struct BaseImageConfig {
+    from: &'static str,
+    install_packages: &'static str,
+    create_user: &'static str,
+}
+
+fn base_image_config(image: &crate::cli::BaseImage) -> BaseImageConfig {
+    use crate::cli::BaseImage;
+    match image {
+        BaseImage::Alpine => BaseImageConfig {
+            from: "alpine:latest",
+            install_packages: "RUN apk add --no-cache curl git vim bash",
+            create_user: "RUN adduser -D -h /home/ai-pod ai-pod && chown -R ai-pod /app",
+        },
+        BaseImage::Ubuntu => BaseImageConfig {
+            from: "ubuntu:latest",
+            install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
+            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
+        },
+        BaseImage::Node => BaseImageConfig {
+            from: "node:lts",
+            install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
+            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
+        },
+        BaseImage::Rust => BaseImageConfig {
+            from: "rust:latest",
+            install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
+            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
+        },
+        BaseImage::Python => BaseImageConfig {
+            from: "python:latest",
+            install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
+            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
+        },
+    }
+}
+
+/// Render the bundled Dockerfile template for the given agent + base image.
+pub fn render_dockerfile(agent: &crate::cli::Agent, image: &crate::cli::BaseImage) -> String {
+    let cfg = base_image_config(image);
+    let agent_str = match agent {
+        crate::cli::Agent::Claude => "claude",
+        crate::cli::Agent::Opencode => "opencode",
+    };
+    let extra = if matches!(agent, crate::cli::Agent::Opencode) {
+        "ENV OPENCODE_YOLO=1"
+    } else {
+        ""
+    };
+    include_str!("../templates/Dockerfile")
+        .replace("{{BASE_IMAGE}}", cfg.from)
+        .replace("{{INSTALL_PACKAGES}}", cfg.install_packages)
+        .replace("{{EXTRA_COMMANDS}}", extra)
+        .replace("{{CREATE_USER}}", cfg.create_user)
+        .replace("{{AGENT}}", agent_str)
+}
+
+/// Write `ai-pod.Dockerfile` into `workspace` (no-op if it already exists,
+/// returning `false` in that case; `true` if a new file was written).
+pub fn write_dockerfile(
+    workspace: &Path,
+    agent: &crate::cli::Agent,
+    image: &crate::cli::BaseImage,
+) -> Result<bool> {
+    let path = workspace.join(DOCKERFILE_NAME);
+    if path.exists() {
+        return Ok(false);
+    }
+    let content = render_dockerfile(agent, image);
+    std::fs::write(&path, content).context("Failed to write ai-pod.Dockerfile")?;
+    Ok(true)
+}
+
 /// Derives a stable, human-readable image name from the workspace path.
 /// Format: `{dirname}-{6-char hash}`, e.g. `myproject-12aef3`.
 pub fn image_name(workspace: &Path) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod container;
 pub mod credentials;
 pub mod env_files_cli;
 pub mod image;
+pub mod manage;
 pub mod runtime;
 pub mod server;
 pub mod service;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use ai_pod::{
-    cli, commands_cli, config, container, credentials, env_files_cli, image, runtime, server,
-    services_cli, update, workspace,
+    cli, commands_cli, config, container, credentials, env_files_cli, image, manage, runtime,
+    server, services_cli, update, workspace,
 };
 
 use anyhow::{Context, Result};
@@ -99,42 +99,6 @@ fn resolve_base_image(agent: &cli::Agent, image: Option<cli::BaseImage>) -> Resu
     Ok(variants[sel].clone())
 }
 
-struct BaseImageConfig {
-    from: &'static str,
-    install_packages: &'static str,
-    create_user: &'static str,
-}
-
-fn base_image_config(image: &cli::BaseImage) -> BaseImageConfig {
-    match image {
-        cli::BaseImage::Alpine => BaseImageConfig {
-            from: "alpine:latest",
-            install_packages: "RUN apk add --no-cache curl git vim bash",
-            create_user: "RUN adduser -D -h /home/ai-pod ai-pod && chown -R ai-pod /app",
-        },
-        cli::BaseImage::Ubuntu => BaseImageConfig {
-            from: "ubuntu:latest",
-            install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
-            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
-        },
-        cli::BaseImage::Node => BaseImageConfig {
-            from: "node:lts",
-            install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
-            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
-        },
-        cli::BaseImage::Rust => BaseImageConfig {
-            from: "rust:latest",
-            install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
-            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
-        },
-        cli::BaseImage::Python => BaseImageConfig {
-            from: "python:latest",
-            install_packages: "RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*",
-            create_user: "RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app",
-        },
-    }
-}
-
 fn init_project(
     workspace: &Path,
     agent: Option<cli::Agent>,
@@ -152,23 +116,9 @@ fn init_project(
     }
 
     let agent = resolve_agent(agent)?;
-    let image = resolve_base_image(&agent, image)?;
+    let base_image = resolve_base_image(&agent, image)?;
 
-    let agent_str = match agent {
-        cli::Agent::Claude => "claude",
-        cli::Agent::Opencode => "opencode",
-    };
-
-    let cfg = base_image_config(&image);
-    let extra_commands = if agent == cli::Agent::Opencode { "ENV OPENCODE_YOLO=1" } else { "" };
-    let content = include_str!("../templates/Dockerfile")
-        .replace("{{BASE_IMAGE}}", cfg.from)
-        .replace("{{INSTALL_PACKAGES}}", cfg.install_packages)
-        .replace("{{EXTRA_COMMANDS}}", extra_commands)
-        .replace("{{CREATE_USER}}", cfg.create_user)
-        .replace("{{AGENT}}", agent_str);
-
-    std::fs::write(&dockerfile, content).context("Failed to write ai-pod.Dockerfile")?;
+    image::write_dockerfile(workspace, &agent, &base_image)?;
 
     println!("{} {}", "Created:".green().bold(), dockerfile.display());
     println!("Edit this file to customise your container, then run `ai-pod` to launch.");
@@ -537,6 +487,10 @@ async fn main() -> Result<()> {
                         .await?;
                 }
             }
+        }
+        Some(Command::Manage) => {
+            manage::run_manage(rt.clone()).await?;
+            return Ok(());
         }
         Some(Command::Services { action }) => {
             let workspace = resolve_workspace(&cli.workdir)?;

--- a/src/manage/agent.rs
+++ b/src/manage/agent.rs
@@ -1,0 +1,65 @@
+//! Enumerate running ai-pod containers and merge them with hook-driven status.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::container::{ManagedContainer, list_managed_containers};
+use crate::runtime::ContainerRuntime;
+
+use super::status::{AgentStatus, StatusEntry};
+
+/// View-model row backing one entry in the manage TUI's left pane.
+#[derive(Clone, Debug)]
+pub struct Agent {
+    pub container_name: String,
+    pub session_id: Option<String>,
+    pub workspace_path: Option<String>,
+    pub project_name: String,
+    pub running: bool,
+    pub status: AgentStatus,
+    pub status_line: String,
+}
+
+impl Agent {
+    fn from_container(c: ManagedContainer, entry: Option<&StatusEntry>) -> Self {
+        let running = matches!(c.state.as_str(), "running" | "Up" | "up")
+            || c.status.to_ascii_lowercase().starts_with("up");
+        let project_name = c
+            .workspace_path
+            .as_deref()
+            .and_then(|p| Path::new(p).file_name().map(|n| n.to_string_lossy().to_string()))
+            .unwrap_or_else(|| c.name.clone());
+        let (status, status_line) = if !running {
+            (AgentStatus::Finished, "exited".to_string())
+        } else if let Some(e) = entry {
+            (e.status.clone(), e.status_line.clone())
+        } else {
+            (AgentStatus::Running, String::new())
+        };
+        Self {
+            container_name: c.name,
+            session_id: c.session_id,
+            workspace_path: c.workspace_path,
+            project_name,
+            running,
+            status,
+            status_line,
+        }
+    }
+}
+
+/// Snapshot the current list of managed containers and join it with the
+/// hook-driven status map.
+pub fn snapshot(rt: &ContainerRuntime, agents_dir: &PathBuf) -> Result<Vec<Agent>> {
+    let containers = list_managed_containers(rt)?;
+    let status_map = super::status::load_all(agents_dir);
+    let agents = containers
+        .into_iter()
+        .map(|c| {
+            let entry = c.session_id.as_deref().and_then(|sid| status_map.get(sid));
+            Agent::from_container(c, entry)
+        })
+        .collect();
+    Ok(agents)
+}

--- a/src/manage/agent.rs
+++ b/src/manage/agent.rs
@@ -35,7 +35,9 @@ impl Agent {
         } else if let Some(e) = entry {
             (e.status.clone(), e.status_line.clone())
         } else {
-            (AgentStatus::Running, String::new())
+            // Container is up but no hook has reported in yet — leave the
+            // row blank rather than claiming a state we can't verify.
+            (AgentStatus::Unknown, String::new())
         };
         Self {
             container_name: c.name,

--- a/src/manage/mod.rs
+++ b/src/manage/mod.rs
@@ -1,0 +1,394 @@
+//! `ai-pod manage` — host-wide TUI for inspecting and driving every running
+//! ai-pod agent. Left pane lists agents (with hook-driven status highlights);
+//! right pane streams the selected agent's pty through a vt100 emulator.
+
+pub mod agent;
+pub mod new_session;
+pub mod status;
+pub mod terminal;
+
+use std::collections::HashMap;
+use std::io::Stdout;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+    MouseButton, MouseEvent, MouseEventKind,
+};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+
+use crate::config::AppConfig;
+use crate::runtime::ContainerRuntime;
+
+use self::agent::Agent;
+use self::status::AgentStatus;
+use self::terminal::AttachedTerm;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Focus {
+    List,
+    Term,
+}
+
+enum Screen {
+    Main,
+    NewSession(new_session::NewSessionState),
+}
+
+struct State {
+    rt: ContainerRuntime,
+    agents_dir: std::path::PathBuf,
+    agents: Vec<Agent>,
+    list_state: ListState,
+    /// Container name → live attached pty.
+    attached: HashMap<String, AttachedTerm>,
+    focus: Focus,
+    last_refresh: Instant,
+    last_pane_layout: Option<(Rect, Rect)>,
+    screen: Screen,
+}
+
+pub async fn run_manage(rt: ContainerRuntime) -> Result<()> {
+    let config = AppConfig::new()?;
+    let agents_dir = config.agents_dir();
+    let _ = std::fs::create_dir_all(&agents_dir);
+
+    enable_raw_mode().context("enable raw mode")?;
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture).context("enter alt screen")?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("create terminal")?;
+
+    let result = run_loop(&mut terminal, rt, agents_dir).await;
+
+    disable_raw_mode().ok();
+    execute!(terminal.backend_mut(), DisableMouseCapture, LeaveAlternateScreen).ok();
+    terminal.show_cursor().ok();
+
+    result
+}
+
+async fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    rt: ContainerRuntime,
+    agents_dir: std::path::PathBuf,
+) -> Result<()> {
+    let mut state = State {
+        rt,
+        agents_dir,
+        agents: Vec::new(),
+        list_state: ListState::default(),
+        attached: HashMap::new(),
+        focus: Focus::List,
+        last_refresh: Instant::now() - Duration::from_secs(60),
+        last_pane_layout: None,
+        screen: Screen::Main,
+    };
+
+    loop {
+        if state.last_refresh.elapsed() > Duration::from_millis(500) {
+            refresh_agents(&mut state);
+            state.last_refresh = Instant::now();
+        }
+
+        draw(terminal, &mut state)?;
+
+        if event::poll(Duration::from_millis(100))? {
+            match event::read()? {
+                Event::Key(k) => {
+                    if k.kind != KeyEventKind::Press {
+                        continue;
+                    }
+                    // Route keys to the modal when it's open, otherwise to
+                    // the main view.
+                    let in_modal = matches!(state.screen, Screen::NewSession(_));
+                    if in_modal {
+                        if let Screen::NewSession(ref mut s) = state.screen {
+                            match new_session::handle_key(s, &k, &state.rt) {
+                                Ok(true) => {
+                                    state.screen = Screen::Main;
+                                    state.last_refresh = Instant::now() - Duration::from_secs(60);
+                                }
+                                Ok(false) => {}
+                                Err(_) => { /* surfaced via the log */ }
+                            }
+                        }
+                    } else if handle_key(&mut state, &k) {
+                        break;
+                    }
+                }
+                Event::Mouse(m) => {
+                    if matches!(state.screen, Screen::Main) {
+                        handle_mouse(&mut state, &m);
+                    }
+                }
+                Event::Resize(_, _) => {
+                    // Layout recomputes on next draw; per-pty resize happens
+                    // inside terminal::render when the inner area changes.
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn refresh_agents(state: &mut State) {
+    let snap = match agent::snapshot(&state.rt, &state.agents_dir) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    // Attach to newly-seen running containers.
+    for a in &snap {
+        if !a.running {
+            continue;
+        }
+        if state.attached.contains_key(&a.container_name) {
+            continue;
+        }
+        if let Ok(term) = AttachedTerm::attach(&state.rt, &a.container_name) {
+            state.attached.insert(a.container_name.clone(), term);
+        }
+    }
+
+    // Drop attachments for containers that are gone.
+    let live: std::collections::HashSet<&str> =
+        snap.iter().map(|a| a.container_name.as_str()).collect();
+    state.attached.retain(|name, _| live.contains(name.as_str()));
+
+    state.agents = snap;
+
+    // Keep the selection in bounds.
+    if state.agents.is_empty() {
+        state.list_state.select(None);
+    } else {
+        let idx = state.list_state.selected().unwrap_or(0);
+        state
+            .list_state
+            .select(Some(idx.min(state.agents.len() - 1)));
+    }
+}
+
+fn selected_agent<'a>(state: &'a State) -> Option<&'a Agent> {
+    state.list_state.selected().and_then(|i| state.agents.get(i))
+}
+
+fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut State) -> Result<()> {
+    let mut pane_layout: Option<(Rect, Rect)> = None;
+    terminal.draw(|f| {
+        let area = f.area();
+        // List pane: capped at 40 cols, but never more than 40% of the width
+        // on narrow terminals.
+        let list_w = (area.width as u32 * 40 / 100).min(40).max(20) as u16;
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(area);
+        let main = chunks[0];
+        let footer = chunks[1];
+
+        let panes = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(list_w), Constraint::Min(20)])
+            .split(main);
+        let list_area = panes[0];
+        let term_area = panes[1];
+        pane_layout = Some((list_area, term_area));
+
+        // ---- list ----
+        let items: Vec<ListItem> = state
+            .agents
+            .iter()
+            .map(|a| {
+                let (glyph, style) = match a.status {
+                    AgentStatus::AwaitingInput => (
+                        "! ",
+                        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                    ),
+                    AgentStatus::Finished => ("✓ ", Style::default().fg(Color::Green)),
+                    AgentStatus::Idle => ("· ", Style::default().fg(Color::DarkGray)),
+                    AgentStatus::Running => ("▶ ", Style::default()),
+                };
+                let project = if a.project_name.len() > 16 {
+                    format!("{}…", &a.project_name[..15])
+                } else {
+                    a.project_name.clone()
+                };
+                let line1 = Line::from(vec![
+                    Span::styled(glyph, style),
+                    Span::styled(project, style),
+                ]);
+                let detail = if !a.status_line.is_empty() {
+                    a.status_line.clone()
+                } else {
+                    match a.status {
+                        AgentStatus::Running => "running".to_string(),
+                        AgentStatus::Idle => "idle".to_string(),
+                        AgentStatus::AwaitingInput => "needs input".to_string(),
+                        AgentStatus::Finished => "finished".to_string(),
+                    }
+                };
+                let detail = if detail.len() > 28 {
+                    format!("  {}…", &detail[..27])
+                } else {
+                    format!("  {}", detail)
+                };
+                let line2 = Line::from(Span::styled(
+                    detail,
+                    Style::default().fg(Color::DarkGray),
+                ));
+                ListItem::new(vec![line1, line2])
+            })
+            .collect();
+
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(if state.focus == Focus::List {
+                        Style::default().fg(Color::Cyan)
+                    } else {
+                        Style::default().fg(Color::DarkGray)
+                    })
+                    .title(format!(" agents ({}) ", state.agents.len())),
+            )
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+        f.render_stateful_widget(list, list_area, &mut state.list_state);
+
+        // ---- terminal pane ----
+        let selected_name = state
+            .list_state
+            .selected()
+            .and_then(|i| state.agents.get(i))
+            .map(|a| a.container_name.clone());
+        let mut cursor_pos: Option<(u16, u16)> = None;
+        if let Some(name) = selected_name.as_deref() {
+            if let Some(term) = state.attached.get_mut(name) {
+                let title = format!(" {} ", name);
+                cursor_pos = term.render(f, term_area, state.focus == Focus::Term, &title);
+            } else {
+                let block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::DarkGray))
+                    .title(format!(" {} (not attached) ", name));
+                f.render_widget(block, term_area);
+            }
+        } else {
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray))
+                .title(" no agent selected ");
+            f.render_widget(block, term_area);
+        }
+
+        // ---- footer ----
+        let hint = match state.focus {
+            Focus::List => " ↑/↓ select · Enter focus terminal · n new session · q quit ",
+            Focus::Term => " F1 back to list  (keys forward to agent) ",
+        };
+        let footer_p = Paragraph::new(hint).style(Style::default().fg(Color::DarkGray));
+        f.render_widget(footer_p, footer);
+
+        if let Some((cx, cy)) = cursor_pos {
+            f.set_cursor_position((cx, cy));
+        }
+
+        if let Screen::NewSession(ref s) = state.screen {
+            new_session::render(s, f, area);
+        }
+    })?;
+    state.last_pane_layout = pane_layout;
+    Ok(())
+}
+
+/// Returns true if the loop should exit.
+fn handle_key(state: &mut State, key: &KeyEvent) -> bool {
+    match state.focus {
+        Focus::List => match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => return true,
+            KeyCode::Down | KeyCode::Char('j') => move_selection(state, 1),
+            KeyCode::Up | KeyCode::Char('k') => move_selection(state, -1),
+            KeyCode::Enter | KeyCode::Tab | KeyCode::F(1) => {
+                if selected_agent(state).is_some() {
+                    state.focus = Focus::Term;
+                }
+            }
+            KeyCode::Char('r') => {
+                state.last_refresh = Instant::now() - Duration::from_secs(60);
+            }
+            KeyCode::Char('n') => {
+                state.screen = Screen::NewSession(new_session::NewSessionState::start());
+            }
+            _ => {}
+        },
+        Focus::Term => {
+            if key.code == KeyCode::F(1) {
+                state.focus = Focus::List;
+                return false;
+            }
+            if let Some(agent) = selected_agent(state) {
+                let name = agent.container_name.clone();
+                if let Some(term) = state.attached.get_mut(&name) {
+                    term.send_key(key);
+                }
+            }
+        }
+    }
+    false
+}
+
+fn handle_mouse(state: &mut State, ev: &MouseEvent) {
+    let (list_area, term_area) = match state.last_pane_layout {
+        Some(l) => l,
+        None => return,
+    };
+    let point = Rect {
+        x: ev.column,
+        y: ev.row,
+        width: 1,
+        height: 1,
+    };
+    let in_list = list_area.intersects(point);
+    let in_term = term_area.intersects(point);
+    match ev.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            if in_list {
+                let inner_top = list_area.y + 1; // border
+                if ev.row >= inner_top {
+                    let offset = ((ev.row - inner_top) / 2) as usize;
+                    if offset < state.agents.len() {
+                        state.list_state.select(Some(offset));
+                    }
+                }
+                state.focus = Focus::List;
+            } else if in_term && selected_agent(state).is_some() {
+                state.focus = Focus::Term;
+            }
+        }
+        MouseEventKind::ScrollDown if in_list => move_selection(state, 1),
+        MouseEventKind::ScrollUp if in_list => move_selection(state, -1),
+        _ => {}
+    }
+}
+
+fn move_selection(state: &mut State, delta: i32) {
+    if state.agents.is_empty() {
+        state.list_state.select(None);
+        return;
+    }
+    let cur = state.list_state.selected().unwrap_or(0) as i32;
+    let next = (cur + delta).clamp(0, state.agents.len() as i32 - 1) as usize;
+    state.list_state.select(Some(next));
+}

--- a/src/manage/mod.rs
+++ b/src/manage/mod.rs
@@ -295,8 +295,8 @@ fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut State) ->
 
         // ---- footer ----
         let hint = match state.focus {
-            Focus::List => " ↑/↓ select · Enter focus terminal · n new session · q quit ",
-            Focus::Term => " F1 back to list  (keys forward to agent) ",
+            Focus::List => " ↑/↓ select · Enter focus terminal · n new session · q/F10 quit ",
+            Focus::Term => " F1 back to list · F10 quit  (other keys → agent) ",
         };
         let footer_p = Paragraph::new(hint).style(Style::default().fg(Color::DarkGray));
         f.render_widget(footer_p, footer);
@@ -315,6 +315,11 @@ fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut State) ->
 
 /// Returns true if the loop should exit.
 fn handle_key(state: &mut State, key: &KeyEvent) -> bool {
+    // Global quit — works from any focus so the user is never stuck inside
+    // the terminal pane with keystrokes being forwarded to the agent.
+    if key.code == KeyCode::F(10) {
+        return true;
+    }
     match state.focus {
         Focus::List => match key.code {
             KeyCode::Char('q') | KeyCode::Esc => return true,

--- a/src/manage/mod.rs
+++ b/src/manage/mod.rs
@@ -294,21 +294,18 @@ fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut State) ->
                         AgentStatus::Unknown => None,
                     }
                 };
-                let lines = match detail {
-                    Some(d) => {
-                        let d = if d.len() > 28 {
-                            format!("  {}…", &d[..27])
-                        } else {
-                            format!("  {}", d)
-                        };
-                        vec![
-                            line1,
-                            Line::from(Span::styled(d, Style::default().fg(Color::DarkGray))),
-                        ]
-                    }
-                    None => vec![line1],
+                // Always render two lines so rows have a consistent height
+                // — empty placeholder when we have no status yet.
+                let detail_text = match detail {
+                    Some(d) if d.len() > 28 => format!("  {}…", &d[..27]),
+                    Some(d) => format!("  {}", d),
+                    None => String::new(),
                 };
-                ListItem::new(lines)
+                let line2 = Line::from(Span::styled(
+                    detail_text,
+                    Style::default().fg(Color::DarkGray),
+                ));
+                ListItem::new(vec![line1, line2])
             })
             .collect();
 

--- a/src/manage/mod.rs
+++ b/src/manage/mod.rs
@@ -131,6 +131,9 @@ async fn run_loop(
             let name = term.container_name.clone();
             state.attached.insert(name.clone(), term);
             state.screen = Screen::Main;
+            // Modal close → clear the host terminal so any residual cells
+            // from the dialog don't linger behind the new frame.
+            terminal.clear().ok();
             refresh_agents(&mut state);
             state.last_refresh = Instant::now();
             if let Some(idx) = state
@@ -160,6 +163,11 @@ async fn run_loop(
                                 Ok(true) => {
                                     state.screen = Screen::Main;
                                     state.last_refresh = Instant::now() - Duration::from_secs(60);
+                                    // Clean slate after the modal — any
+                                    // cells the dialog touched get fully
+                                    // repainted from the main view next
+                                    // tick.
+                                    terminal.clear().ok();
                                 }
                                 Ok(false) => {}
                                 Err(_) => { /* surfaced via the log */ }

--- a/src/manage/mod.rs
+++ b/src/manage/mod.rs
@@ -14,7 +14,8 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
-    MouseButton, MouseEvent, MouseEventKind,
+    KeyboardEnhancementFlags, MouseButton, MouseEvent, MouseEventKind,
+    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
 use crossterm::terminal::{
@@ -66,12 +67,27 @@ pub async fn run_manage(rt: ContainerRuntime) -> Result<()> {
     enable_raw_mode().context("enable raw mode")?;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture).context("enter alt screen")?;
+    // Best-effort: ask the terminal to report modifier-disambiguated key
+    // events (kitty keyboard protocol). Without this, Shift+Enter arrives
+    // as plain Enter on most terminals. Silently ignored if the host
+    // terminal doesn't support it.
+    let kbd_enhanced = execute!(
+        stdout,
+        PushKeyboardEnhancementFlags(
+            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+        )
+    )
+    .is_ok();
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).context("create terminal")?;
 
     let result = run_loop(&mut terminal, rt, agents_dir).await;
 
     disable_raw_mode().ok();
+    if kbd_enhanced {
+        let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
+    }
     execute!(terminal.backend_mut(), DisableMouseCapture, LeaveAlternateScreen).ok();
     terminal.show_cursor().ok();
 
@@ -99,6 +115,32 @@ async fn run_loop(
         if state.last_refresh.elapsed() > Duration::from_millis(500) {
             refresh_agents(&mut state);
             state.last_refresh = Instant::now();
+        }
+
+        // While the new-session modal is open, drain any launch events the
+        // background task has produced. On success the task hands us a
+        // ready-to-go AttachedTerm — we plug it straight into state.attached,
+        // close the modal, and jump to the terminal pane. This means we only
+        // touch the channel when the modal is actually open, instead of
+        // polling for an outcome every frame.
+        let mut handed_term: Option<AttachedTerm> = None;
+        if let Screen::NewSession(ref mut s) = state.screen {
+            handed_term = new_session::drain_launch_events(s);
+        }
+        if let Some(term) = handed_term {
+            let name = term.container_name.clone();
+            state.attached.insert(name.clone(), term);
+            state.screen = Screen::Main;
+            refresh_agents(&mut state);
+            state.last_refresh = Instant::now();
+            if let Some(idx) = state
+                .agents
+                .iter()
+                .position(|a| a.container_name == name)
+            {
+                state.list_state.select(Some(idx));
+                state.focus = Focus::Term;
+            }
         }
 
         draw(terminal, &mut state)?;
@@ -268,13 +310,23 @@ fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut State) ->
         f.render_stateful_widget(list, list_area, &mut state.list_state);
 
         // ---- terminal pane ----
+        // When the new-session modal is open we skip rendering the agent's
+        // vt100 grid entirely: the modal only Clears its own rect, so any
+        // cells the pane writes outside the modal's bounds would "leak"
+        // around the popover.
+        let modal_open = matches!(state.screen, Screen::NewSession(_));
         let selected_name = state
             .list_state
             .selected()
             .and_then(|i| state.agents.get(i))
             .map(|a| a.container_name.clone());
         let mut cursor_pos: Option<(u16, u16)> = None;
-        if let Some(name) = selected_name.as_deref() {
+        if modal_open {
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray));
+            f.render_widget(block, term_area);
+        } else if let Some(name) = selected_name.as_deref() {
             if let Some(term) = state.attached.get_mut(name) {
                 let title = format!(" {} ", name);
                 cursor_pos = term.render(f, term_area, state.focus == Focus::Term, &title);
@@ -301,8 +353,10 @@ fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut State) ->
         let footer_p = Paragraph::new(hint).style(Style::default().fg(Color::DarkGray));
         f.render_widget(footer_p, footer);
 
-        if let Some((cx, cy)) = cursor_pos {
-            f.set_cursor_position((cx, cy));
+        if !modal_open {
+            if let Some((cx, cy)) = cursor_pos {
+                f.set_cursor_position((cx, cy));
+            }
         }
 
         if let Screen::NewSession(ref s) = state.screen {

--- a/src/manage/mod.rs
+++ b/src/manage/mod.rs
@@ -270,6 +270,9 @@ fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut State) ->
                     AgentStatus::Finished => ("✓ ", Style::default().fg(Color::Green)),
                     AgentStatus::Idle => ("· ", Style::default().fg(Color::DarkGray)),
                     AgentStatus::Running => ("▶ ", Style::default()),
+                    // No hook has reported in yet — render the row without a
+                    // status glyph or text rather than claiming a state.
+                    AgentStatus::Unknown => ("  ", Style::default()),
                 };
                 let project = if a.project_name.len() > 16 {
                     format!("{}…", &a.project_name[..15])
@@ -281,25 +284,31 @@ fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut State) ->
                     Span::styled(project, style),
                 ]);
                 let detail = if !a.status_line.is_empty() {
-                    a.status_line.clone()
+                    Some(a.status_line.clone())
                 } else {
                     match a.status {
-                        AgentStatus::Running => "running".to_string(),
-                        AgentStatus::Idle => "idle".to_string(),
-                        AgentStatus::AwaitingInput => "needs input".to_string(),
-                        AgentStatus::Finished => "finished".to_string(),
+                        AgentStatus::Running => Some("running".to_string()),
+                        AgentStatus::Idle => Some("idle".to_string()),
+                        AgentStatus::AwaitingInput => Some("needs input".to_string()),
+                        AgentStatus::Finished => Some("finished".to_string()),
+                        AgentStatus::Unknown => None,
                     }
                 };
-                let detail = if detail.len() > 28 {
-                    format!("  {}…", &detail[..27])
-                } else {
-                    format!("  {}", detail)
+                let lines = match detail {
+                    Some(d) => {
+                        let d = if d.len() > 28 {
+                            format!("  {}…", &d[..27])
+                        } else {
+                            format!("  {}", d)
+                        };
+                        vec![
+                            line1,
+                            Line::from(Span::styled(d, Style::default().fg(Color::DarkGray))),
+                        ]
+                    }
+                    None => vec![line1],
                 };
-                let line2 = Line::from(Span::styled(
-                    detail,
-                    Style::default().fg(Color::DarkGray),
-                ));
-                ListItem::new(vec![line1, line2])
+                ListItem::new(lines)
             })
             .collect();
 
@@ -446,6 +455,22 @@ fn handle_mouse(state: &mut State, ev: &MouseEvent) {
         }
         MouseEventKind::ScrollDown if in_list => move_selection(state, 1),
         MouseEventKind::ScrollUp if in_list => move_selection(state, -1),
+        MouseEventKind::ScrollDown | MouseEventKind::ScrollUp if in_term => {
+            // Forward wheel events to the agent's pty. AttachedTerm checks
+            // whether the agent has actually enabled mouse mode; if it
+            // hasn't, the call is a no-op.
+            let up = matches!(ev.kind, MouseEventKind::ScrollUp);
+            let inner_x = term_area.x + 1;
+            let inner_y = term_area.y + 1;
+            let col = ev.column.saturating_sub(inner_x).saturating_add(1);
+            let row = ev.row.saturating_sub(inner_y).saturating_add(1);
+            let name = selected_agent(state).map(|a| a.container_name.clone());
+            if let Some(name) = name {
+                if let Some(term) = state.attached.get_mut(&name) {
+                    term.send_scroll(up, col, row);
+                }
+            }
+        }
         _ => {}
     }
 }

--- a/src/manage/new_session.rs
+++ b/src/manage/new_session.rs
@@ -743,21 +743,41 @@ fn render_launching(
     frame.render_widget(p, chunks[2]);
 }
 
-/// Truncate a string to a max display width, appending `…` if shortened. We
-/// count chars rather than bytes because non-ASCII chars commonly appear in
-/// log output (the ellipsis itself, status icons, etc.); `width` is close
-/// enough to terminal columns for typical content.
+/// Truncate a string to a max display-column width, appending `…` if
+/// shortened. Strips control characters (including embedded \n, \r, and
+/// ANSI escapes) and uses Unicode display width so wide glyphs (emoji,
+/// CJK) are counted as the 2 columns they actually occupy on screen.
+/// Without this, build-output lines with control codes or wide chars
+/// would render past the modal border.
 fn truncate_to(s: &str, max: usize) -> String {
+    use unicode_width::UnicodeWidthChar;
     if max == 0 {
         return String::new();
     }
-    let count = s.chars().count();
-    if count <= max {
-        return s.to_string();
+    let limit = max.saturating_sub(1); // reserve one cell for the ellipsis
+    let mut width = 0usize;
+    let mut out = String::new();
+    let mut truncated = false;
+    for c in s.chars() {
+        // Drop anything that could cause the terminal to do something other
+        // than print a glyph in its own cell.
+        if c.is_control() && c != ' ' {
+            continue;
+        }
+        let cw = c.width().unwrap_or(0);
+        if cw == 0 {
+            continue;
+        }
+        if width + cw > limit {
+            truncated = true;
+            break;
+        }
+        width += cw;
+        out.push(c);
     }
-    let take = max.saturating_sub(1);
-    let mut out: String = s.chars().take(take).collect();
-    out.push('…');
+    if truncated {
+        out.push('…');
+    }
     out
 }
 

--- a/src/manage/new_session.rs
+++ b/src/manage/new_session.rs
@@ -1,0 +1,712 @@
+//! New-session flow inside `ai-pod manage`: pick (or create) a workspace
+//! directory, optionally create an ai-pod.Dockerfile, and start a detached
+//! agent container that the TUI then attaches to.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+
+use crate::cli::{Agent, BaseImage};
+use crate::config::AppConfig;
+use crate::runtime::ContainerRuntime;
+
+/// What the new-session modal is currently showing.
+pub enum Stage {
+    Picking {
+        input: String,
+        candidates: Vec<PathBuf>,
+        list_state: ListState,
+        // Known projects from ~/.ai-pod/*.json (used when input is empty).
+        known: Vec<PathBuf>,
+    },
+    PickAgent {
+        workspace: PathBuf,
+        agents: Vec<Agent>,
+        list_state: ListState,
+    },
+    PickImage {
+        workspace: PathBuf,
+        agent: Agent,
+        images: Vec<BaseImage>,
+        list_state: ListState,
+    },
+    Launching {
+        workspace: PathBuf,
+        log: Arc<Mutex<Vec<String>>>,
+        done: Arc<AtomicBool>,
+        error: Arc<Mutex<Option<String>>>,
+    },
+}
+
+pub struct NewSessionState {
+    pub stage: Stage,
+}
+
+impl NewSessionState {
+    pub fn start() -> Self {
+        let known = known_projects();
+        let mut list_state = ListState::default();
+        if !known.is_empty() {
+            list_state.select(Some(0));
+        }
+        let candidates = known.clone();
+        Self {
+            stage: Stage::Picking {
+                input: String::new(),
+                candidates,
+                list_state,
+                known,
+            },
+        }
+    }
+}
+
+/// Drive a key event. Returns:
+/// - `Ok(true)` → close the modal (return to main view)
+/// - `Ok(false)` → stay in the modal
+pub fn handle_key(
+    state: &mut NewSessionState,
+    key: &KeyEvent,
+    rt: &ContainerRuntime,
+) -> Result<bool> {
+    // Esc always closes (except while a launch is in progress; let the user
+    // close once it's done).
+    if key.code == KeyCode::Esc {
+        if matches!(&state.stage, Stage::Launching { done, .. } if !done.load(Ordering::Acquire)) {
+            return Ok(false);
+        }
+        return Ok(true);
+    }
+
+    // Some arms transition out of the current stage by calling start_launch /
+    // advance_after_pick, which both mutate state.stage. To avoid a double
+    // mutable borrow we collect the transition data here and run the
+    // transition after the match.
+    enum Transition {
+        None,
+        Pick(PathBuf),
+        Launch(PathBuf),
+    }
+    let mut transition = Transition::None;
+
+    match &mut state.stage {
+        Stage::Picking {
+            input,
+            candidates,
+            list_state,
+            known,
+        } => match key.code {
+            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                input.push(c);
+                refresh_candidates(input, candidates, list_state, known);
+            }
+            KeyCode::Backspace => {
+                input.pop();
+                refresh_candidates(input, candidates, list_state, known);
+            }
+            KeyCode::Down => {
+                if !candidates.is_empty() {
+                    let cur = list_state.selected().unwrap_or(0);
+                    list_state.select(Some((cur + 1).min(candidates.len() - 1)));
+                }
+            }
+            KeyCode::Up => {
+                let cur = list_state.selected().unwrap_or(0);
+                list_state.select(Some(cur.saturating_sub(1)));
+            }
+            KeyCode::Tab => {
+                // Complete to the selected candidate.
+                if let Some(idx) = list_state.selected() {
+                    if let Some(path) = candidates.get(idx) {
+                        *input = path.to_string_lossy().to_string();
+                        if !input.ends_with('/') {
+                            input.push('/');
+                        }
+                        refresh_candidates(input, candidates, list_state, known);
+                    }
+                }
+            }
+            KeyCode::Enter => {
+                let path = resolve_picked_path(input, candidates, list_state)?;
+                transition = Transition::Pick(path);
+            }
+            _ => {}
+        },
+        Stage::PickAgent {
+            workspace,
+            agents,
+            list_state,
+        } => match key.code {
+            KeyCode::Down | KeyCode::Char('j') => {
+                let cur = list_state.selected().unwrap_or(0);
+                list_state.select(Some((cur + 1).min(agents.len() - 1)));
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                let cur = list_state.selected().unwrap_or(0);
+                list_state.select(Some(cur.saturating_sub(1)));
+            }
+            KeyCode::Enter => {
+                let idx = list_state.selected().unwrap_or(0);
+                let agent = agents[idx].clone();
+                let images: Vec<BaseImage> = match agent {
+                    Agent::Claude => vec![
+                        BaseImage::Alpine,
+                        BaseImage::Ubuntu,
+                        BaseImage::Node,
+                        BaseImage::Rust,
+                        BaseImage::Python,
+                    ],
+                    Agent::Opencode => vec![
+                        BaseImage::Ubuntu,
+                        BaseImage::Node,
+                        BaseImage::Rust,
+                        BaseImage::Python,
+                    ],
+                };
+                let mut new_state = ListState::default();
+                new_state.select(Some(0));
+                state.stage = Stage::PickImage {
+                    workspace: workspace.clone(),
+                    agent,
+                    images,
+                    list_state: new_state,
+                };
+            }
+            _ => {}
+        },
+        Stage::PickImage {
+            workspace,
+            agent,
+            images,
+            list_state,
+        } => match key.code {
+            KeyCode::Down | KeyCode::Char('j') => {
+                let cur = list_state.selected().unwrap_or(0);
+                list_state.select(Some((cur + 1).min(images.len() - 1)));
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                let cur = list_state.selected().unwrap_or(0);
+                list_state.select(Some(cur.saturating_sub(1)));
+            }
+            KeyCode::Enter => {
+                let idx = list_state.selected().unwrap_or(0);
+                let image = images[idx].clone();
+                crate::image::write_dockerfile(workspace, agent, &image)?;
+                transition = Transition::Launch(workspace.clone());
+            }
+            _ => {}
+        },
+        Stage::Launching { done, .. } => {
+            // Enter/space closes once we're done.
+            if matches!(key.code, KeyCode::Enter | KeyCode::Char(' '))
+                && done.load(Ordering::Acquire)
+            {
+                return Ok(true);
+            }
+        }
+    }
+
+    match transition {
+        Transition::None => {}
+        Transition::Pick(path) => advance_after_pick(state, path)?,
+        Transition::Launch(path) => start_launch(state, rt.clone(), path),
+    }
+    Ok(false)
+}
+
+fn refresh_candidates(
+    input: &str,
+    candidates: &mut Vec<PathBuf>,
+    list_state: &mut ListState,
+    known: &[PathBuf],
+) {
+    if input.is_empty() {
+        *candidates = known.to_vec();
+    } else {
+        *candidates = directory_completions(input);
+    }
+    if candidates.is_empty() {
+        list_state.select(None);
+    } else {
+        list_state.select(Some(0));
+    }
+}
+
+/// Decide which path the user picked when they pressed Enter on the picker.
+/// Prefers the highlighted candidate if the input matches its parent; falls
+/// back to the raw input. The chosen path is then expanded (~ → $HOME) and
+/// canonicalised if it already exists.
+fn resolve_picked_path(
+    input: &str,
+    candidates: &[PathBuf],
+    list_state: &ListState,
+) -> Result<PathBuf> {
+    let raw = if input.is_empty() {
+        list_state
+            .selected()
+            .and_then(|i| candidates.get(i))
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default()
+    } else {
+        input.to_string()
+    };
+    if raw.is_empty() {
+        anyhow::bail!("No path provided");
+    }
+    Ok(expand_tilde(&raw))
+}
+
+fn expand_tilde(s: &str) -> PathBuf {
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    } else if s == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    PathBuf::from(s)
+}
+
+/// Read every `~/.ai-pod/{hash}.json` (skip `server.json`) and return their
+/// `workspace` paths, deduplicated and sorted.
+fn known_projects() -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let config = match AppConfig::new() {
+        Ok(c) => c,
+        Err(_) => return out,
+    };
+    let dir = match std::fs::read_dir(&config.config_dir) {
+        Ok(d) => d,
+        Err(_) => return out,
+    };
+    for entry in dir.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        if path.file_stem().and_then(|s| s.to_str()) == Some("server") {
+            continue;
+        }
+        let state = crate::server::lifecycle::ProjectState::load(&path);
+        if !state.workspace.is_empty() {
+            out.push(PathBuf::from(state.workspace));
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Filesystem-based directory completion for the typed path. Splits the input
+/// into `(dirname, basename_prefix)` and lists immediate subdirectories of
+/// `dirname` whose name starts with the prefix.
+fn directory_completions(input: &str) -> Vec<PathBuf> {
+    let expanded = expand_tilde(input);
+    let (parent, prefix) = if input.ends_with('/') {
+        (expanded.clone(), String::new())
+    } else {
+        let parent = expanded
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("."));
+        let prefix = expanded
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        (parent, prefix)
+    };
+    let parent = if parent.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        parent
+    };
+    let mut out: Vec<PathBuf> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&parent) {
+        for e in entries.flatten() {
+            let name = e.file_name();
+            let name_s = name.to_string_lossy().to_string();
+            if name_s.starts_with('.') && !prefix.starts_with('.') {
+                continue;
+            }
+            if !prefix.is_empty() && !name_s.starts_with(&prefix) {
+                continue;
+            }
+            let p = e.path();
+            if p.is_dir() {
+                out.push(p);
+            }
+        }
+    }
+    out.sort();
+    out.truncate(50);
+    out
+}
+
+fn advance_after_pick(state: &mut NewSessionState, path: PathBuf) -> Result<()> {
+    // Auto-create the directory if it doesn't exist (user-confirmed default).
+    if !path.exists() {
+        std::fs::create_dir_all(&path)?;
+    }
+    let workspace = std::fs::canonicalize(&path).unwrap_or(path);
+    let dockerfile = workspace.join(crate::image::DOCKERFILE_NAME);
+    if dockerfile.exists() {
+        // Skip straight to launch.
+        let rt = ContainerRuntime::detect(false)?;
+        start_launch(state, rt, workspace);
+        return Ok(());
+    }
+    // No Dockerfile → walk through the init wizard.
+    let mut list_state = ListState::default();
+    list_state.select(Some(0));
+    state.stage = Stage::PickAgent {
+        workspace,
+        agents: vec![Agent::Claude, Agent::Opencode],
+        list_state,
+    };
+    Ok(())
+}
+
+/// Spawn a background tokio task that runs the full launch flow in detached
+/// mode and pipes progress into `log`. The TUI watches `done` / `error` to
+/// know when to allow closing the modal.
+fn start_launch(state: &mut NewSessionState, rt: ContainerRuntime, workspace: PathBuf) {
+    let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let done = Arc::new(AtomicBool::new(false));
+    let error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+    let log_t = log.clone();
+    let done_t = done.clone();
+    let error_t = error.clone();
+    let workspace_t = workspace.clone();
+
+    tokio::spawn(async move {
+        let push = |msg: &str| {
+            if let Ok(mut g) = log_t.lock() {
+                g.push(msg.to_string());
+            }
+        };
+        let result: Result<()> = (async {
+            let config = AppConfig::new()?;
+            config.init()?;
+
+            push("Ensuring shared server is running...");
+            crate::server::lifecycle::ensure_shared_server(&config).await?;
+
+            push("Building image (this can take a few minutes)...");
+            let image_name = crate::image::image_name(&workspace_t);
+            let dockerfile = workspace_t.join(crate::image::DOCKERFILE_NAME);
+            // Run the synchronous build off the async runtime so we don't
+            // starve other tasks (the UI keeps drawing in the meantime).
+            let rt_b = rt.clone();
+            let dockerfile_b = dockerfile.clone();
+            let image_b = image_name.clone();
+            tokio::task::spawn_blocking(move || {
+                crate::image::ensure_image(&rt_b, &dockerfile_b, &image_b, false, false)
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("build task join: {e}"))??;
+
+            crate::server::lifecycle::bump_keep_alive().await;
+            crate::server::lifecycle::check_server_version().await?;
+
+            push("Preparing project state...");
+            let project_id = crate::workspace::workspace_hash(&workspace_t);
+            let state =
+                crate::server::lifecycle::get_or_create_project_state(&config, &workspace_t)?;
+            crate::server::lifecycle::reload_config().await?;
+
+            push("Starting detached container...");
+            let rt_l = rt.clone();
+            let workspace_l = workspace_t.clone();
+            let config_l = AppConfig::new()?;
+            let image_l = image_name.clone();
+            let api_key_l = state.api_key.clone();
+            let project_id_l = project_id.clone();
+            let name = tokio::task::spawn_blocking(move || {
+                crate::container::start_container_detached(
+                    &rt_l,
+                    &config_l,
+                    &workspace_l,
+                    &image_l,
+                    &project_id_l,
+                    &api_key_l,
+                )
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("launch task join: {e}"))??;
+
+            push(&format!("Container started: {name}"));
+            Ok(())
+        })
+        .await;
+
+        match result {
+            Ok(()) => {
+                push("Done. Press Enter to close.");
+            }
+            Err(e) => {
+                push(&format!("ERROR: {e}"));
+                if let Ok(mut g) = error_t.lock() {
+                    *g = Some(e.to_string());
+                }
+            }
+        }
+        done_t.store(true, Ordering::Release);
+    });
+
+    state.stage = Stage::Launching {
+        workspace,
+        log,
+        done,
+        error,
+    };
+}
+
+/// Render the modal centred over `area`. Caller draws the main view first;
+/// the modal overlays it.
+pub fn render(state: &NewSessionState, frame: &mut Frame<'_>, area: Rect) {
+    let modal = centred(area, 80, 24);
+    frame.render_widget(Clear, modal);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(" new session ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+
+    match &state.stage {
+        Stage::Picking {
+            input,
+            candidates,
+            list_state,
+            ..
+        } => render_picking(frame, inner, input, candidates, list_state),
+        Stage::PickAgent {
+            workspace,
+            agents,
+            list_state,
+        } => render_agent_pick(frame, inner, workspace, agents, list_state),
+        Stage::PickImage {
+            workspace,
+            agent,
+            images,
+            list_state,
+        } => render_image_pick(frame, inner, workspace, agent, images, list_state),
+        Stage::Launching {
+            workspace,
+            log,
+            done,
+            error,
+        } => render_launching(frame, inner, workspace, log, done, error),
+    }
+}
+
+fn render_picking(
+    frame: &mut Frame<'_>,
+    inner: Rect,
+    input: &str,
+    candidates: &[PathBuf],
+    list_state: &ListState,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let title = if input.is_empty() {
+        " Path  (type to search dirs; ↑/↓ Enter to pick known project)"
+    } else {
+        " Path  (Tab complete · Enter use this path)"
+    };
+    let prompt = Paragraph::new(format!("> {input}_"))
+        .block(Block::default().borders(Borders::ALL).title(title));
+    frame.render_widget(prompt, chunks[0]);
+
+    let label = if input.is_empty() {
+        " Known projects "
+    } else {
+        " Completions "
+    };
+    let items: Vec<ListItem> = candidates
+        .iter()
+        .map(|p| ListItem::new(p.to_string_lossy().to_string()))
+        .collect();
+    let mut ls = list_state.clone();
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(label))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_stateful_widget(list, chunks[1], &mut ls);
+
+    let hint = Paragraph::new(" Enter pick · Tab complete · Esc cancel ")
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(hint, chunks[2]);
+}
+
+fn render_agent_pick(
+    frame: &mut Frame<'_>,
+    inner: Rect,
+    workspace: &Path,
+    agents: &[Agent],
+    list_state: &ListState,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(3), Constraint::Length(1)])
+        .split(inner);
+
+    let header = Paragraph::new(vec![
+        Line::from(format!("No ai-pod.Dockerfile in {}", workspace.display())),
+        Line::from(Span::styled(
+            "Pick an agent to bootstrap one.",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ])
+    .block(Block::default().borders(Borders::ALL).title(" init "));
+    frame.render_widget(header, chunks[0]);
+
+    let items: Vec<ListItem> = agents
+        .iter()
+        .map(|a| {
+            ListItem::new(match a {
+                Agent::Claude => "Claude",
+                Agent::Opencode => "OpenCode",
+            })
+        })
+        .collect();
+    let mut ls = list_state.clone();
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(" agent "))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_stateful_widget(list, chunks[1], &mut ls);
+
+    let hint = Paragraph::new(" ↑/↓ select · Enter pick · Esc cancel ")
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(hint, chunks[2]);
+}
+
+fn render_image_pick(
+    frame: &mut Frame<'_>,
+    inner: Rect,
+    workspace: &Path,
+    agent: &Agent,
+    images: &[BaseImage],
+    list_state: &ListState,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(3), Constraint::Length(1)])
+        .split(inner);
+
+    let header = Paragraph::new(vec![
+        Line::from(format!("Workspace: {}", workspace.display())),
+        Line::from(format!(
+            "Agent: {}",
+            match agent {
+                Agent::Claude => "Claude",
+                Agent::Opencode => "OpenCode",
+            }
+        )),
+    ])
+    .block(Block::default().borders(Borders::ALL).title(" init "));
+    frame.render_widget(header, chunks[0]);
+
+    let items: Vec<ListItem> = images
+        .iter()
+        .map(|i| {
+            ListItem::new(match i {
+                BaseImage::Alpine => "Alpine",
+                BaseImage::Ubuntu => "Ubuntu",
+                BaseImage::Node => "Node",
+                BaseImage::Rust => "Rust",
+                BaseImage::Python => "Python",
+            })
+        })
+        .collect();
+    let mut ls = list_state.clone();
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(" base image "))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_stateful_widget(list, chunks[1], &mut ls);
+
+    let hint = Paragraph::new(" ↑/↓ select · Enter create + launch · Esc cancel ")
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(hint, chunks[2]);
+}
+
+fn render_launching(
+    frame: &mut Frame<'_>,
+    inner: Rect,
+    workspace: &Path,
+    log: &Arc<Mutex<Vec<String>>>,
+    done: &Arc<AtomicBool>,
+    error: &Arc<Mutex<Option<String>>>,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(3), Constraint::Length(1)])
+        .split(inner);
+
+    let header = Paragraph::new(format!("Launching agent for {}", workspace.display()))
+        .block(Block::default().borders(Borders::ALL).title(" launch "));
+    frame.render_widget(header, chunks[0]);
+
+    let lines: Vec<Line> = log
+        .lock()
+        .map(|g| {
+            g.iter()
+                .rev()
+                .take(chunks[1].height.saturating_sub(2) as usize)
+                .rev()
+                .map(|s| {
+                    if s.starts_with("ERROR") {
+                        Line::from(Span::styled(s.clone(), Style::default().fg(Color::Red)))
+                    } else {
+                        Line::from(s.clone())
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let body = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title(" log "));
+    frame.render_widget(body, chunks[1]);
+
+    let is_done = done.load(Ordering::Acquire);
+    let has_err = error.lock().map(|g| g.is_some()).unwrap_or(false);
+    let hint = if !is_done {
+        " building..."
+    } else if has_err {
+        " failed · Esc/Enter to close "
+    } else {
+        " done · Enter to close "
+    };
+    let p = Paragraph::new(hint).style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(p, chunks[2]);
+}
+
+fn centred(area: Rect, max_w: u16, max_h: u16) -> Rect {
+    let w = max_w.min(area.width.saturating_sub(2));
+    let h = max_h.min(area.height.saturating_sub(2));
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    }
+}

--- a/src/manage/new_session.rs
+++ b/src/manage/new_session.rs
@@ -3,8 +3,6 @@
 //! agent container that the TUI then attaches to.
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -13,10 +11,24 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use crate::cli::{Agent, BaseImage};
 use crate::config::AppConfig;
 use crate::runtime::ContainerRuntime;
+
+use super::terminal::AttachedTerm;
+
+/// Events streamed from the background launch task into the modal. Once
+/// `Done` or `Error` arrives the task exits and the channel sender is
+/// dropped; no polling needed beyond draining whatever is queued each frame.
+pub enum LaunchEvent {
+    Log(String),
+    /// `podman run -d -it` succeeded and we already attached a pty to it.
+    /// The main loop inserts the term directly into `state.attached`.
+    Done(AttachedTerm),
+    Error(String),
+}
 
 /// What the new-session modal is currently showing.
 pub enum Stage {
@@ -40,9 +52,12 @@ pub enum Stage {
     },
     Launching {
         workspace: PathBuf,
-        log: Arc<Mutex<Vec<String>>>,
-        done: Arc<AtomicBool>,
-        error: Arc<Mutex<Option<String>>>,
+        log: Vec<String>,
+        rx: UnboundedReceiver<LaunchEvent>,
+        /// `None` while the task is still running; `Some(Ok())` on success
+        /// (the AttachedTerm has already been handed to the main loop), or
+        /// `Some(Err(msg))` if the task failed.
+        result: Option<std::result::Result<(), String>>,
     },
 }
 
@@ -80,7 +95,7 @@ pub fn handle_key(
     // Esc always closes (except while a launch is in progress; let the user
     // close once it's done).
     if key.code == KeyCode::Esc {
-        if matches!(&state.stage, Stage::Launching { done, .. } if !done.load(Ordering::Acquire)) {
+        if matches!(&state.stage, Stage::Launching { result, .. } if result.is_none()) {
             return Ok(false);
         }
         return Ok(true);
@@ -204,11 +219,10 @@ pub fn handle_key(
             }
             _ => {}
         },
-        Stage::Launching { done, .. } => {
-            // Enter/space closes once we're done.
-            if matches!(key.code, KeyCode::Enter | KeyCode::Char(' '))
-                && done.load(Ordering::Acquire)
-            {
+        Stage::Launching { result, .. } => {
+            // Enter/space closes once we're done. On success the main loop
+            // already auto-closed; this is the manual fallback (errors).
+            if matches!(key.code, KeyCode::Enter | KeyCode::Char(' ')) && result.is_some() {
                 return Ok(true);
             }
         }
@@ -380,33 +394,23 @@ fn advance_after_pick(state: &mut NewSessionState, path: PathBuf) -> Result<()> 
 /// mode and pipes progress into `log`. The TUI watches `done` / `error` to
 /// know when to allow closing the modal.
 fn start_launch(state: &mut NewSessionState, rt: ContainerRuntime, workspace: PathBuf) {
-    let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    let done = Arc::new(AtomicBool::new(false));
-    let error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-
-    let log_t = log.clone();
-    let done_t = done.clone();
-    let error_t = error.clone();
+    let (tx, rx) = unbounded_channel::<LaunchEvent>();
     let workspace_t = workspace.clone();
 
     tokio::spawn(async move {
-        let push = |msg: &str| {
-            if let Ok(mut g) = log_t.lock() {
-                g.push(msg.to_string());
-            }
+        let log = |tx: &UnboundedSender<LaunchEvent>, msg: &str| {
+            let _ = tx.send(LaunchEvent::Log(msg.to_string()));
         };
-        let result: Result<()> = (async {
+        let result: Result<AttachedTerm> = (async {
             let config = AppConfig::new()?;
             config.init()?;
 
-            push("Ensuring shared server is running...");
+            log(&tx, "Ensuring shared server is running...");
             crate::server::lifecycle::ensure_shared_server(&config).await?;
 
-            push("Building image (this can take a few minutes)...");
+            log(&tx, "Building image (this can take a few minutes)...");
             let image_name = crate::image::image_name(&workspace_t);
             let dockerfile = workspace_t.join(crate::image::DOCKERFILE_NAME);
-            // Run the synchronous build off the async runtime so we don't
-            // starve other tasks (the UI keeps drawing in the meantime).
             let rt_b = rt.clone();
             let dockerfile_b = dockerfile.clone();
             let image_b = image_name.clone();
@@ -419,57 +423,95 @@ fn start_launch(state: &mut NewSessionState, rt: ContainerRuntime, workspace: Pa
             crate::server::lifecycle::bump_keep_alive().await;
             crate::server::lifecycle::check_server_version().await?;
 
-            push("Preparing project state...");
+            log(&tx, "Preparing project state...");
             let project_id = crate::workspace::workspace_hash(&workspace_t);
-            let state =
+            let proj_state =
                 crate::server::lifecycle::get_or_create_project_state(&config, &workspace_t)?;
             crate::server::lifecycle::reload_config().await?;
 
-            push("Starting detached container...");
+            log(&tx, "Starting detached container...");
+            // Run the synchronous container start + pty attach off the async
+            // runtime, then ship the live AttachedTerm back to the main loop.
             let rt_l = rt.clone();
             let workspace_l = workspace_t.clone();
             let config_l = AppConfig::new()?;
             let image_l = image_name.clone();
-            let api_key_l = state.api_key.clone();
+            let api_key_l = proj_state.api_key.clone();
             let project_id_l = project_id.clone();
-            let name = tokio::task::spawn_blocking(move || {
-                crate::container::start_container_detached(
+            let term = tokio::task::spawn_blocking(move || -> Result<AttachedTerm> {
+                let name = crate::container::start_container_detached(
                     &rt_l,
                     &config_l,
                     &workspace_l,
                     &image_l,
                     &project_id_l,
                     &api_key_l,
-                )
+                )?;
+                // Immediately attach to the new container's pty so the main
+                // loop can take ownership without an extra round-trip
+                // through refresh_agents().
+                let term = AttachedTerm::attach(&rt_l, &name)?;
+                Ok(term)
             })
             .await
             .map_err(|e| anyhow::anyhow!("launch task join: {e}"))??;
 
-            push(&format!("Container started: {name}"));
-            Ok(())
+            Ok(term)
         })
         .await;
 
         match result {
-            Ok(()) => {
-                push("Done. Press Enter to close.");
+            Ok(term) => {
+                let _ = tx.send(LaunchEvent::Done(term));
             }
             Err(e) => {
-                push(&format!("ERROR: {e}"));
-                if let Ok(mut g) = error_t.lock() {
-                    *g = Some(e.to_string());
-                }
+                let msg = e.to_string();
+                let _ = tx.send(LaunchEvent::Error(msg));
             }
         }
-        done_t.store(true, Ordering::Release);
+        // tx drops here → main loop sees the channel close after draining.
     });
 
     state.stage = Stage::Launching {
         workspace,
-        log,
-        done,
-        error,
+        log: Vec::new(),
+        rx,
+        result: None,
     };
+}
+
+/// Drain whatever events the launch task has sent so far into the modal
+/// state. Returns the AttachedTerm when the task finished successfully so
+/// the caller can plug it into `state.attached` and auto-close the modal.
+pub fn drain_launch_events(state: &mut NewSessionState) -> Option<AttachedTerm> {
+    let Stage::Launching {
+        log, rx, result, ..
+    } = &mut state.stage
+    else {
+        return None;
+    };
+    if result.is_some() {
+        return None;
+    }
+    let mut term_out: Option<AttachedTerm> = None;
+    loop {
+        match rx.try_recv() {
+            Ok(LaunchEvent::Log(msg)) => log.push(msg),
+            Ok(LaunchEvent::Done(term)) => {
+                log.push(format!("Container started: {}", term.container_name));
+                *result = Some(Ok(()));
+                term_out = Some(term);
+                break;
+            }
+            Ok(LaunchEvent::Error(msg)) => {
+                log.push(format!("ERROR: {msg}"));
+                *result = Some(Err(msg));
+                break;
+            }
+            Err(_) => break, // empty or closed
+        }
+    }
+    term_out
 }
 
 /// Render the modal centred over `area`. Caller draws the main view first;
@@ -505,9 +547,9 @@ pub fn render(state: &NewSessionState, frame: &mut Frame<'_>, area: Rect) {
         Stage::Launching {
             workspace,
             log,
-            done,
-            error,
-        } => render_launching(frame, inner, workspace, log, done, error),
+            result,
+            ..
+        } => render_launching(frame, inner, workspace, log, result),
     }
 }
 
@@ -651,51 +693,72 @@ fn render_launching(
     frame: &mut Frame<'_>,
     inner: Rect,
     workspace: &Path,
-    log: &Arc<Mutex<Vec<String>>>,
-    done: &Arc<AtomicBool>,
-    error: &Arc<Mutex<Option<String>>>,
+    log: &[String],
+    result: &Option<std::result::Result<(), String>>,
 ) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(3), Constraint::Min(3), Constraint::Length(1)])
         .split(inner);
 
-    let header = Paragraph::new(format!("Launching agent for {}", workspace.display()))
+    let workspace_str = workspace.display().to_string();
+    // Inner area of the header block is chunks[0].width - 2 (left + right borders).
+    let header_text = truncate_to(
+        &format!("Launching agent for {workspace_str}"),
+        chunks[0].width.saturating_sub(2) as usize,
+    );
+    let header = Paragraph::new(header_text)
         .block(Block::default().borders(Borders::ALL).title(" launch "));
     frame.render_widget(header, chunks[0]);
 
+    // Log body. Long lines are truncated with an ellipsis so they can never
+    // spill past the modal — image builds in particular like to emit very
+    // long lines (full layer ids, urls, etc.).
+    let inner_w = chunks[1].width.saturating_sub(2) as usize;
+    let inner_h = chunks[1].height.saturating_sub(2) as usize;
     let lines: Vec<Line> = log
-        .lock()
-        .map(|g| {
-            g.iter()
-                .rev()
-                .take(chunks[1].height.saturating_sub(2) as usize)
-                .rev()
-                .map(|s| {
-                    if s.starts_with("ERROR") {
-                        Line::from(Span::styled(s.clone(), Style::default().fg(Color::Red)))
-                    } else {
-                        Line::from(s.clone())
-                    }
-                })
-                .collect()
+        .iter()
+        .rev()
+        .take(inner_h)
+        .rev()
+        .map(|s| {
+            let trimmed = truncate_to(s, inner_w);
+            if s.starts_with("ERROR") {
+                Line::from(Span::styled(trimmed, Style::default().fg(Color::Red)))
+            } else {
+                Line::from(trimmed)
+            }
         })
-        .unwrap_or_default();
+        .collect();
     let body = Paragraph::new(lines)
         .block(Block::default().borders(Borders::ALL).title(" log "));
     frame.render_widget(body, chunks[1]);
 
-    let is_done = done.load(Ordering::Acquire);
-    let has_err = error.lock().map(|g| g.is_some()).unwrap_or(false);
-    let hint = if !is_done {
-        " building..."
-    } else if has_err {
-        " failed · Esc/Enter to close "
-    } else {
-        " done · Enter to close "
+    let hint = match result {
+        None => " building...",
+        Some(Ok(())) => " done · Enter to close ",
+        Some(Err(_)) => " failed · Esc/Enter to close ",
     };
     let p = Paragraph::new(hint).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(p, chunks[2]);
+}
+
+/// Truncate a string to a max display width, appending `…` if shortened. We
+/// count chars rather than bytes because non-ASCII chars commonly appear in
+/// log output (the ellipsis itself, status icons, etc.); `width` is close
+/// enough to terminal columns for typical content.
+fn truncate_to(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    let count = s.chars().count();
+    if count <= max {
+        return s.to_string();
+    }
+    let take = max.saturating_sub(1);
+    let mut out: String = s.chars().take(take).collect();
+    out.push('…');
+    out
 }
 
 fn centred(area: Rect, max_w: u16, max_h: u16) -> Rect {

--- a/src/manage/new_session.rs
+++ b/src/manage/new_session.rs
@@ -446,6 +446,7 @@ fn start_launch(state: &mut NewSessionState, rt: ContainerRuntime, workspace: Pa
                     &image_l,
                     &project_id_l,
                     &api_key_l,
+                    None,
                 )?;
                 // Immediately attach to the new container's pty so the main
                 // loop can take ownership without an extra round-trip

--- a/src/manage/status.rs
+++ b/src/manage/status.rs
@@ -1,0 +1,78 @@
+//! Read per-session status files written by Claude/OpenCode hooks via the
+//! `POST /agent_status` server endpoint. Each file lives at
+//! `~/.local/share/ai-pod/agents/{session_id}.json`.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AgentStatus {
+    Running,
+    Idle,
+    AwaitingInput,
+    Finished,
+}
+
+impl AgentStatus {
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "Idle" => Self::Idle,
+            "AwaitingInput" => Self::AwaitingInput,
+            "Finished" => Self::Finished,
+            _ => Self::Running,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct StatusEntry {
+    pub status: AgentStatus,
+    pub status_line: String,
+}
+
+#[derive(Deserialize)]
+struct StatusFile {
+    status: String,
+    #[serde(default)]
+    status_line: String,
+}
+
+/// Read every status file in `agents_dir` and return a session_id → entry map.
+/// Returns an empty map if the directory doesn't exist.
+pub fn load_all(agents_dir: &PathBuf) -> HashMap<String, StatusEntry> {
+    let mut out = HashMap::new();
+    let entries = match std::fs::read_dir(agents_dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let session_id = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        if session_id.starts_with('.') {
+            continue;
+        }
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let parsed: StatusFile = match serde_json::from_str(&raw) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        out.insert(
+            session_id,
+            StatusEntry {
+                status: AgentStatus::from_str(&parsed.status),
+                status_line: parsed.status_line,
+            },
+        );
+    }
+    out
+}

--- a/src/manage/status.rs
+++ b/src/manage/status.rs
@@ -8,6 +8,9 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AgentStatus {
+    /// No hook event has been received for this session yet — we know the
+    /// container is up but have no signal from the agent itself.
+    Unknown,
     Running,
     Idle,
     AwaitingInput,
@@ -20,7 +23,8 @@ impl AgentStatus {
             "Idle" => Self::Idle,
             "AwaitingInput" => Self::AwaitingInput,
             "Finished" => Self::Finished,
-            _ => Self::Running,
+            "Running" => Self::Running,
+            _ => Self::Unknown,
         }
     }
 }

--- a/src/manage/terminal.rs
+++ b/src/manage/terminal.rs
@@ -48,6 +48,11 @@ impl AttachedTerm {
         // Pick a detach sequence the user is extremely unlikely to type.
         // The default ctrl-p,ctrl-q would silently detach the agent's input.
         cmd.arg("--detach-keys=ctrl-^,ctrl-^");
+        // Do NOT forward signals from our attach pty to the container — when
+        // the TUI exits and the pty closes, the resulting SIGHUP would
+        // otherwise propagate into the container and kill the agent. We want
+        // exit to behave like a detach, so the container keeps running.
+        cmd.arg("--sig-proxy=false");
         cmd.arg(container_name);
         // Inherit no env from the parent — `podman` reads its own config.
         cmd.env("TERM", "xterm-256color");
@@ -152,7 +157,16 @@ impl AttachedTerm {
                     buf.extend_from_slice(c.to_string().as_bytes());
                 }
             }
-            KeyCode::Enter => buf.push(b'\r'),
+            // Shift+Enter → Alt+CR (`\x1b\r`). Claude Code (and most modern
+            // terminal chat UIs) treat this as "insert newline" rather than
+            // "submit". Plain Enter stays `\r`.
+            KeyCode::Enter => {
+                if key.modifiers.contains(KeyModifiers::SHIFT) {
+                    buf.extend_from_slice(b"\x1b\r");
+                } else {
+                    buf.push(b'\r');
+                }
+            }
             KeyCode::Tab => buf.push(b'\t'),
             KeyCode::BackTab => buf.extend_from_slice(b"\x1b[Z"),
             KeyCode::Backspace => buf.push(0x7f),

--- a/src/manage/terminal.rs
+++ b/src/manage/terminal.rs
@@ -115,6 +115,12 @@ impl AttachedTerm {
         self.alive.load(Ordering::Acquire)
     }
 
+    /// Forward a wheel scroll to the agent's pty. Stubbed for now —
+    /// emitting a proper SGR mouse sequence requires us to know which
+    /// mouse protocol mode the agent has enabled, and most TUIs we care
+    /// about (claude, opencode) don't use the wheel anyway.
+    pub fn send_scroll(&mut self, _up: bool, _col: u16, _row: u16) {}
+
     /// Adjust pty + parser to the given pane size (subtracting borders).
     pub fn resize(&mut self, rows: u16, cols: u16) {
         if rows == self.rows && cols == self.cols {

--- a/src/manage/terminal.rs
+++ b/src/manage/terminal.rs
@@ -1,0 +1,289 @@
+//! Per-agent attached terminal: drives a `podman attach` child through a pty,
+//! feeds its output into a vt100 emulator, and forwards keystrokes back.
+
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
+use ratatui::layout::Rect;
+use ratatui::style::{Color as TuiColor, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::runtime::ContainerRuntime;
+
+/// Bookkeeping for a single attached agent terminal.
+pub struct AttachedTerm {
+    pub container_name: String,
+    parser: Arc<Mutex<vt100::Parser>>,
+    master: Box<dyn MasterPty + Send>,
+    writer: Box<dyn Write + Send>,
+    _child: Box<dyn portable_pty::Child + Send + Sync>,
+    pub dirty: Arc<AtomicBool>,
+    pub alive: Arc<AtomicBool>,
+    rows: u16,
+    cols: u16,
+}
+
+impl AttachedTerm {
+    pub fn attach(rt: &ContainerRuntime, container_name: &str) -> Result<Self> {
+        let rows: u16 = 40;
+        let cols: u16 = 120;
+
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .with_context(|| format!("openpty for {}", container_name))?;
+
+        let mut cmd = CommandBuilder::new(rt.cmd());
+        cmd.arg("attach");
+        // Pick a detach sequence the user is extremely unlikely to type.
+        // The default ctrl-p,ctrl-q would silently detach the agent's input.
+        cmd.arg("--detach-keys=ctrl-^,ctrl-^");
+        cmd.arg(container_name);
+        // Inherit no env from the parent — `podman` reads its own config.
+        cmd.env("TERM", "xterm-256color");
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .with_context(|| format!("spawn podman attach {}", container_name))?;
+
+        // Slave is now owned by the child process.
+        drop(pair.slave);
+
+        let mut reader = pair
+            .master
+            .try_clone_reader()
+            .context("clone pty reader")?;
+        let writer = pair.master.take_writer().context("take pty writer")?;
+
+        let parser = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 0)));
+        let dirty = Arc::new(AtomicBool::new(true));
+        let alive = Arc::new(AtomicBool::new(true));
+
+        // Reader task: blocking read of the pty master, feed bytes into the
+        // vt100 parser, flip the dirty flag for the UI tick.
+        let parser_reader = parser.clone();
+        let dirty_reader = dirty.clone();
+        let alive_reader = alive.clone();
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if let Ok(mut p) = parser_reader.lock() {
+                            p.process(&buf[..n]);
+                        }
+                        dirty_reader.store(true, Ordering::Release);
+                    }
+                    Err(_) => break,
+                }
+            }
+            alive_reader.store(false, Ordering::Release);
+            dirty_reader.store(true, Ordering::Release);
+        });
+
+        Ok(Self {
+            container_name: container_name.to_string(),
+            parser,
+            master: pair.master,
+            writer,
+            _child: child,
+            dirty,
+            alive,
+            rows,
+            cols,
+        })
+    }
+
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Acquire)
+    }
+
+    /// Adjust pty + parser to the given pane size (subtracting borders).
+    pub fn resize(&mut self, rows: u16, cols: u16) {
+        if rows == self.rows && cols == self.cols {
+            return;
+        }
+        self.rows = rows.max(1);
+        self.cols = cols.max(1);
+        let _ = self.master.resize(PtySize {
+            rows: self.rows,
+            cols: self.cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+        if let Ok(mut p) = self.parser.lock() {
+            p.screen_mut().set_size(self.rows, self.cols);
+        }
+        self.dirty.store(true, Ordering::Release);
+    }
+
+    /// Convert a crossterm KeyEvent into terminal bytes and write to the pty.
+    pub fn send_key(&mut self, key: &KeyEvent) {
+        let mut buf: Vec<u8> = Vec::with_capacity(8);
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+        match key.code {
+            KeyCode::Char(c) => {
+                if ctrl {
+                    // Ctrl-A..Ctrl-Z → 0x01..0x1A
+                    let lower = c.to_ascii_lowercase();
+                    if ('a'..='z').contains(&lower) {
+                        buf.push((lower as u8) - b'a' + 1);
+                    } else {
+                        // Fall back to literal char for unsupported ctrl combos.
+                        buf.extend_from_slice(c.to_string().as_bytes());
+                    }
+                } else {
+                    if alt {
+                        buf.push(0x1b);
+                    }
+                    buf.extend_from_slice(c.to_string().as_bytes());
+                }
+            }
+            KeyCode::Enter => buf.push(b'\r'),
+            KeyCode::Tab => buf.push(b'\t'),
+            KeyCode::BackTab => buf.extend_from_slice(b"\x1b[Z"),
+            KeyCode::Backspace => buf.push(0x7f),
+            KeyCode::Esc => buf.push(0x1b),
+            KeyCode::Up => buf.extend_from_slice(b"\x1b[A"),
+            KeyCode::Down => buf.extend_from_slice(b"\x1b[B"),
+            KeyCode::Right => buf.extend_from_slice(b"\x1b[C"),
+            KeyCode::Left => buf.extend_from_slice(b"\x1b[D"),
+            KeyCode::Home => buf.extend_from_slice(b"\x1b[H"),
+            KeyCode::End => buf.extend_from_slice(b"\x1b[F"),
+            KeyCode::PageUp => buf.extend_from_slice(b"\x1b[5~"),
+            KeyCode::PageDown => buf.extend_from_slice(b"\x1b[6~"),
+            KeyCode::Delete => buf.extend_from_slice(b"\x1b[3~"),
+            KeyCode::Insert => buf.extend_from_slice(b"\x1b[2~"),
+            _ => {}
+        }
+        if buf.is_empty() {
+            return;
+        }
+        let _ = self.writer.write_all(&buf);
+        let _ = self.writer.flush();
+    }
+
+    /// Render the current vt100 screen into `area`, drawing a titled border
+    /// around it. The cursor inside `area` is returned for the caller to
+    /// position when this pane has focus.
+    pub fn render(
+        &mut self,
+        frame: &mut ratatui::Frame<'_>,
+        area: Rect,
+        focused: bool,
+        title: &str,
+    ) -> Option<(u16, u16)> {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(if focused {
+                Style::default().fg(TuiColor::Cyan)
+            } else {
+                Style::default().fg(TuiColor::DarkGray)
+            })
+            .title(title.to_string());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        // Resize the pty to match the inner pane if it changed.
+        self.resize(inner.height, inner.width);
+
+        let mut lines: Vec<Line> = Vec::with_capacity(inner.height as usize);
+        let cursor;
+        {
+            let parser = self.parser.lock().expect("parser lock poisoned");
+            let screen = parser.screen();
+            let (rows, cols) = (inner.height, inner.width);
+            for row in 0..rows {
+                let mut spans: Vec<Span> = Vec::new();
+                for col in 0..cols {
+                    let cell = screen.cell(row, col);
+                    let (text, style) = match cell {
+                        Some(c) => {
+                            let mut style = Style::default();
+                            style.fg = vt_color_to_ratatui(c.fgcolor());
+                            style.bg = vt_color_to_ratatui(c.bgcolor());
+                            let mut mods = Modifier::empty();
+                            if c.bold() {
+                                mods |= Modifier::BOLD;
+                            }
+                            if c.italic() {
+                                mods |= Modifier::ITALIC;
+                            }
+                            if c.underline() {
+                                mods |= Modifier::UNDERLINED;
+                            }
+                            if c.inverse() {
+                                mods |= Modifier::REVERSED;
+                            }
+                            style.add_modifier = mods;
+                            let s = c.contents().to_string();
+                            let s = if s.is_empty() { " ".to_string() } else { s };
+                            (s, style)
+                        }
+                        None => (" ".to_string(), Style::default()),
+                    };
+                    spans.push(Span::styled(text, style));
+                }
+                lines.push(Line::from(spans));
+            }
+            let (cy, cx) = screen.cursor_position();
+            cursor = Some((cy, cx));
+        }
+
+        let para = Paragraph::new(lines);
+        frame.render_widget(para, inner);
+
+        self.dirty.store(false, Ordering::Release);
+
+        if focused {
+            cursor.and_then(|(cy, cx)| {
+                if cy < inner.height && cx < inner.width {
+                    Some((inner.x + cx, inner.y + cy))
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        }
+    }
+}
+
+fn vt_color_to_ratatui(c: vt100::Color) -> Option<TuiColor> {
+    match c {
+        vt100::Color::Default => None,
+        vt100::Color::Idx(i) => Some(match i {
+            0 => TuiColor::Black,
+            1 => TuiColor::Red,
+            2 => TuiColor::Green,
+            3 => TuiColor::Yellow,
+            4 => TuiColor::Blue,
+            5 => TuiColor::Magenta,
+            6 => TuiColor::Cyan,
+            7 => TuiColor::Gray,
+            8 => TuiColor::DarkGray,
+            9 => TuiColor::LightRed,
+            10 => TuiColor::LightGreen,
+            11 => TuiColor::LightYellow,
+            12 => TuiColor::LightBlue,
+            13 => TuiColor::LightMagenta,
+            14 => TuiColor::LightCyan,
+            15 => TuiColor::White,
+            n => TuiColor::Indexed(n),
+        }),
+        vt100::Color::Rgb(r, g, b) => Some(TuiColor::Rgb(r, g, b)),
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -166,6 +166,7 @@ pub fn build_app(state: AppState) -> Router {
         .route("/keep-alive", post(keep_alive_handler))
         .route("/reload", post(reload_handler))
         .route("/notify_user", post(rest::notify_user_handler))
+        .route("/agent_status", post(rest::agent_status_handler))
         .route("/list_allowed_commands", post(rest::list_allowed_commands_handler))
         .route("/commands/run", post(rest::run_command_handler))
         .route("/commands/stop", post(rest::stop_command_handler))

--- a/src/server/rest.rs
+++ b/src/server/rest.rs
@@ -78,6 +78,20 @@ pub struct ListAllowedCommandsResponse {
     pub commands: Vec<String>,
 }
 
+#[derive(Deserialize)]
+pub struct AgentStatusRequest {
+    pub project_id: String,
+    pub session_id: String,
+    pub status: String,
+    #[serde(default)]
+    pub status_line: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct AgentStatusResponse {
+    pub ok: bool,
+}
+
 fn extract_api_key(headers: &HeaderMap) -> &str {
     headers
         .get("x-api-key")
@@ -226,6 +240,83 @@ pub async fn notify_user_handler(
     notify::send_notification(&format!("ai-pod {}", project_name), &req.message);
 
     Json(NotifyUserResponse { ok: true }).into_response()
+}
+
+pub async fn agent_status_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<AgentStatusRequest>,
+) -> impl IntoResponse {
+    let provided_key = extract_api_key(&headers).to_string();
+    if let Err((status, msg)) = authenticate(&state, &req.project_id, &provided_key).await {
+        return (status, msg.to_string()).into_response();
+    }
+
+    // Whitelist the allowed status values.
+    let normalised = match req.status.as_str() {
+        "Running" | "Idle" | "AwaitingInput" | "Finished" => req.status.as_str(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                "status must be one of Running, Idle, AwaitingInput, Finished",
+            )
+                .into_response();
+        }
+    };
+
+    // Reject session ids that aren't 8 hex chars to keep the filename safe.
+    if req.session_id.len() != 8 || !req.session_id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return (StatusCode::BAD_REQUEST, "Invalid session_id").into_response();
+    }
+
+    let agents_dir = {
+        let home = match dirs::data_local_dir().or_else(dirs::data_dir) {
+            Some(p) => p,
+            None => {
+                return (StatusCode::INTERNAL_SERVER_ERROR, "no data dir").into_response();
+            }
+        };
+        home.join("ai-pod").join("agents")
+    };
+    if let Err(e) = std::fs::create_dir_all(&agents_dir) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("create agents_dir: {e}"),
+        )
+            .into_response();
+    }
+
+    let updated_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    let payload = serde_json::json!({
+        "session_id": req.session_id,
+        "project_id": req.project_id,
+        "status": normalised,
+        "status_line": req.status_line.clone().unwrap_or_default(),
+        "updated_at": updated_at,
+    });
+
+    let final_path = agents_dir.join(format!("{}.json", req.session_id));
+    let tmp_path = agents_dir.join(format!(".{}.json.tmp", req.session_id));
+    if let Err(e) = std::fs::write(&tmp_path, payload.to_string()) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("write status: {e}"),
+        )
+            .into_response();
+    }
+    if let Err(e) = std::fs::rename(&tmp_path, &final_path) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("commit status: {e}"),
+        )
+            .into_response();
+    }
+
+    Json(AgentStatusResponse { ok: true }).into_response()
 }
 
 pub async fn list_allowed_commands_handler(

--- a/templates/opencode-plugin.js
+++ b/templates/opencode-plugin.js
@@ -2,25 +2,48 @@ export const AiPodPlugin = async ({ project }) => {
   const url = (process.env.AI_POD_SERVER_URL || "").replace(/\/+$/, "");
   const apiKey = process.env.AI_POD_API_KEY || "";
   const projectId = process.env.AI_POD_PROJECT_ID || "";
+  const sessionId = process.env.AI_POD_SESSION_ID || "";
+
+  const post = async (path, body) => {
+    if (!url || !apiKey || !projectId) return;
+    try {
+      await fetch(`${url}${path}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Api-Key": apiKey,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      // Best-effort; ignore failures.
+    }
+  };
+
+  const reportStatus = (status, line) =>
+    sessionId
+      ? post("/agent_status", {
+          project_id: projectId,
+          session_id: sessionId,
+          status,
+          status_line: line,
+        })
+      : Promise.resolve();
+
+  const title = project?.name || "OpenCode";
+
   return {
     "session.idle": async () => {
-      if (!url || !apiKey || !projectId) return;
-      const title = project?.name || "OpenCode";
-      try {
-        await fetch(`${url}/notify_user`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Api-Key": apiKey,
-          },
-          body: JSON.stringify({
-            project_id: projectId,
-            message: `${title}: Task completed`,
-          }),
-        });
-      } catch {
-        // Best-effort notification; ignore failures.
-      }
+      await post("/notify_user", {
+        project_id: projectId,
+        message: `${title}: Task completed`,
+      });
+      await reportStatus("Idle", "Task completed");
+    },
+    "chat.params": async () => {
+      // Fires when OpenCode is about to send a request to the model — the
+      // user has just submitted a prompt and work is starting.
+      await reportStatus("Running", "Working...");
     },
   };
 };


### PR DESCRIPTION
Adds `ai-pod manage`, a host-wide TUI for inspecting and driving every running ai-pod agent. Left pane lists agents (with hook-driven status highlights); right pane streams the selected agent's pty through a vt100 emulator. Press `n` to launch a new session from a path picker that autocompletes against the filesystem and known projects, walks through the Dockerfile init wizard when needed, and runs the full build/launch flow in the background with a live progress log.

Hook-driven status: Claude Stop / Notification hooks now also POST to a new authenticated /agent_status endpoint, which writes per-session JSON under ~/.local/share/ai-pod/agents/. The TUI polls that directory to flag agents that are idle, awaiting input, or finished.