### PR TITLE
feat: forward stdio in `ai-pod run` for ACP/IDE integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,34 @@ ai-pod run claude resume   # resume the last Claude session
 ai-pod run bash            # open a bash shell in the container
 ```
 
+### IDE integration via ACP
+
+`ai-pod run` forwards stdio transparently between the parent process and the in-container command. When stdin is not a terminal — i.e. an IDE is piping JSON-RPC over `ai-pod`'s stdio — ai-pod drops the pseudo-TTY allocation and keeps status output on stderr, so the byte stream coming out of the container is exactly what the IDE sees. That makes any agent that speaks the [Agent Client Protocol](https://agentclientprotocol.com/) usable from inside the container.
+
+Run your workspace through `ai-pod` once first, so the credential triage and home volume are set up. Then point your IDE at `ai-pod run …` with the in-container ACP binary as the command. For Claude Code:
+
+```jsonc
+// Zed: ~/.config/zed/settings.json
+{
+  "agent_servers": {
+    "ai-pod (claude)": {
+      "command": "ai-pod",
+      "args": [
+        "--no-credential-check",
+        "--workdir", "/absolute/path/to/workspace",
+        "run", "claude-code-acp"
+      ]
+    }
+  }
+}
+```
+
+For OpenCode, use whichever ACP entry point it exposes (e.g. `ai-pod run opencode acp`). Anything you install into your `ai-pod.Dockerfile` is on `$PATH` inside the container, so `npm i -g @zed-industries/claude-code-acp` in the Dockerfile is enough to make the example above work.
+
+Notes:
+- Pass `--no-credential-check` (or run `ai-pod` interactively first to triage the workspace) — the credential dialog can't run without a TTY, and ai-pod will refuse to start if anything is pending.
+- `--workdir` is required when the IDE launches `ai-pod` from a directory other than the workspace root.
+
 ### Masking host directories
 
 Some directories — `node_modules`, `target`, `.venv`, `dist` — contain

--- a/ai-pod.Dockerfile
+++ b/ai-pod.Dockerfile
@@ -1,25 +1,23 @@
 FROM rust:latest
 
-ARG HOST_GATEWAY
-RUN curl -fsSL "http://${HOST_GATEWAY}:7822/host-tools" \
-      -o /usr/local/bin/host-tools && chmod +x /usr/local/bin/host-tools
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*
 
-RUN host-tools install claude
-RUN host-tools install opencode
+ARG HOST_GATEWAY
+ARG AI_POD_VERSION
+RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/claude.sh" | bash
+RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/opencode.sh" | bash
 
 WORKDIR /app
 
-RUN useradd -ms /bin/bash ai-pod
-RUN chown -R ai-pod /app
+RUN useradd -ms /bin/bash ai-pod && chown -R ai-pod /app
 
-# System-level git identity
+# System-level git identity (fallback when no host identity is provided)
 RUN git config --system user.email "ai-pod@ai-pod" && \
     git config --system user.name "ai-pod"
 
 USER ai-pod
 
 ENV PATH="/home/ai-pod/.local/bin:${PATH}"
-ENV OPENCODE_YOLO=1
-
+ENV EDITOR=vim
 
 CMD ["claude"]

--- a/src/container.rs
+++ b/src/container.rs
@@ -93,7 +93,7 @@ fn ensure_mask_volume(
 ) -> Result<String> {
     let vol = mask_volume_name(workspace, dir);
     if !volume_exists(rt, &vol)? {
-        println!("{} {}", "Creating mask volume:".blue().bold(), vol);
+        eprintln!("{} {}", "Creating mask volume:".blue().bold(), vol);
         let status = rt
             .command()
             .args(["volume", "create", &vol])
@@ -212,10 +212,10 @@ pub fn remove_mask_volume(rt: &ContainerRuntime, workspace: &Path, dir: &str) ->
         .output()
         .context("Failed to remove mask volume")?;
     if output.status.success() {
-        println!("{} {}", "Removed volume:".red().bold(), vol);
+        eprintln!("{} {}", "Removed volume:".red().bold(), vol);
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        println!(
+        eprintln!(
             "{} could not remove {} ({})",
             "Warning:".yellow().bold(),
             vol,
@@ -566,7 +566,7 @@ fn init_home_volume(
     project_id: &str,
     api_key: &str,
 ) -> Result<()> {
-    println!(
+    eprintln!(
         "{} {}",
         "Initialising home volume:".blue().bold(),
         volume_name
@@ -585,7 +585,7 @@ fn init_home_volume(
 
     let _ = (project_id, api_key); // used via env vars at runtime
 
-    println!("{}", "Home volume initialised.".green());
+    eprintln!("{}", "Home volume initialised.".green());
 
     Ok(())
 }
@@ -601,7 +601,7 @@ fn reseed_home_volume(
     project_id: &str,
     api_key: &str,
 ) -> Result<()> {
-    println!(
+    eprintln!(
         "{} {}",
         "Refreshing home volume config:".blue().bold(),
         volume_name
@@ -611,7 +611,7 @@ fn reseed_home_volume(
 
     let _ = (project_id, api_key); // used via env vars at runtime
 
-    println!("{}", "Home volume reseeded.".green());
+    eprintln!("{}", "Home volume reseeded.".green());
 
     Ok(())
 }
@@ -632,7 +632,7 @@ pub fn launch_container(
     // On rebuild: stop all existing containers for this workspace and reseed the volume
     if rebuild {
         for name in containers_for_prefix(rt, &prefix, false)? {
-            println!(
+            eprintln!(
                 "{} {}",
                 "Removing container for rebuild:".blue().bold(),
                 name
@@ -667,7 +667,7 @@ pub fn launch_container(
 
     let session_id = new_session_id();
     let container_name = container_name_for(workspace, &session_id);
-    println!("{} {}", "Starting container:".blue().bold(), container_name);
+    eprintln!("{} {}", "Starting container:".blue().bold(), container_name);
 
     refresh_claude_mcp_in_volume(
         rt,
@@ -762,6 +762,7 @@ pub fn run_in_container(
     api_key: &str,
     command: &str,
     args: &[String],
+    interactive: bool,
 ) -> Result<()> {
     let session_id = new_session_id();
     let container_name = container_name_for(workspace, &session_id);
@@ -792,7 +793,7 @@ pub fn run_in_container(
         &session_id,
     )?;
 
-    println!(
+    eprintln!(
         "{} {} {}",
         "Running in container:".blue().bold(),
         container_name,
@@ -809,10 +810,14 @@ pub fn run_in_container(
     // attached later on rootless podman.
     let service_net = crate::service::ensure_service_network(rt, workspace)?;
 
+    // Without a tty on stdin (e.g. an IDE driving ai-pod over stdio for
+    // ACP), `-t` would allocate a pseudo-TTY that mangles the JSON-RPC
+    // byte stream the agent emits. Keep `-i` so stdin stays attached.
+    let stdio_flag = if interactive { "-it" } else { "-i" };
     let mut run_args: Vec<String> = vec![
         "run".into(),
         "--rm".into(),
-        "-it".into(),
+        stdio_flag.into(),
     ];
     run_args.extend_from_slice(&[
         "--label".into(),

--- a/src/image.rs
+++ b/src/image.rs
@@ -54,7 +54,7 @@ pub fn needs_build(rt: &ContainerRuntime, image: &str, force: bool) -> Result<bo
 }
 
 pub fn build_image(rt: &ContainerRuntime, dockerfile: &Path, image: &str, no_cache: bool) -> Result<()> {
-    println!("{}", "Building container image...".blue().bold());
+    eprintln!("{}", "Building container image...".blue().bold());
 
     let version_arg = format!("AI_POD_VERSION={}", env!("CARGO_PKG_VERSION"));
     let gateway_arg = format!("HOST_GATEWAY={}", rt.host_gateway());
@@ -113,7 +113,7 @@ pub fn build_image(rt: &ContainerRuntime, dockerfile: &Path, image: &str, no_cac
         anyhow::bail!("{} build failed", rt.cmd());
     }
 
-    println!("{}", "Image built successfully.".green().bold());
+    eprintln!("{}", "Image built successfully.".green().bold());
     Ok(())
 }
 
@@ -121,7 +121,7 @@ pub fn ensure_image(rt: &ContainerRuntime, dockerfile: &Path, image: &str, force
     if needs_build(rt, image, force)? {
         build_image(rt, dockerfile, image, no_cache)?;
     } else {
-        println!("{}", "Container image is up to date.".green());
+        eprintln!("{}", "Container image is up to date.".green());
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,12 @@ pub mod service;
 pub mod services_cli;
 pub mod update;
 pub mod workspace;
+
+/// Returns true if stdin is connected to a terminal. When false, ai-pod
+/// is being driven by another program (e.g. an IDE speaking ACP over
+/// stdio); status output must stay on stderr and the container's stdio
+/// must not get a pseudo-TTY allocated.
+pub fn is_stdin_tty() -> bool {
+    // Safety: isatty just reads the fd's terminal state, no aliasing concerns.
+    unsafe { libc::isatty(0) == 1 }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,7 @@ async fn launch_flow(cli: &Cli, rt: &ContainerRuntime) -> Result<()> {
 
     // 1. Resolve workspace
     let workspace = resolve_workspace(&cli.workdir)?;
-    println!("{} {}", "Workspace:".blue(), workspace.display());
+    eprintln!("{} {}", "Workspace:".blue(), workspace.display());
 
     // 2. Locate Dockerfile
     let dockerfile = workspace.join(image::DOCKERFILE_NAME);
@@ -244,7 +244,7 @@ async fn launch_flow(cli: &Cli, rt: &ContainerRuntime) -> Result<()> {
     // 3. Credential scan
     if !cli.no_credential_check {
         if !credentials::check_credentials(&workspace, &config)? {
-            println!("{}", "Aborted.".red());
+            eprintln!("{}", "Aborted.".red());
             return Ok(());
         }
     }
@@ -293,8 +293,12 @@ async fn launch_flow(cli: &Cli, rt: &ContainerRuntime) -> Result<()> {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Skip update check for internal/daemon commands
-    if !matches!(&cli.command, Some(Command::Serve) | Some(Command::Update)) {
+    // Skip update check for internal/daemon commands and when stdin isn't a
+    // tty — the latter means we're being driven by another program (e.g. an
+    // IDE speaking ACP), and the 3s blocking lookup just delays agent startup.
+    if !matches!(&cli.command, Some(Command::Serve) | Some(Command::Update))
+        && ai_pod::is_stdin_tty()
+    {
         let _ = tokio::time::timeout(
             std::time::Duration::from_secs(3),
             update::check_for_update(),
@@ -499,9 +503,25 @@ async fn main() -> Result<()> {
                     workspace.display()
                 );
             }
+            let interactive = ai_pod::is_stdin_tty();
             if !cli.no_credential_check {
-                if !credentials::check_credentials(&workspace, &config)? {
-                    println!("{}", "Aborted.".red());
+                // Without a tty we cannot run the dialoguer-based triage. Run
+                // the silent scan instead: succeed if nothing is pending, else
+                // emit a clear error pointing the user at the interactive flow.
+                if !interactive {
+                    let hash = workspace::workspace_hash(&workspace);
+                    let state = server::lifecycle::ProjectState::load(
+                        &config.project_state_file(&hash),
+                    );
+                    let pending = credentials::pending_credentials(&workspace, &state);
+                    if !pending.is_empty() {
+                        anyhow::bail!(
+                            "Workspace has {} un-triaged sensitive file(s). Run `ai-pod` interactively to review them, or pass `--no-credential-check`.",
+                            pending.len()
+                        );
+                    }
+                } else if !credentials::check_credentials(&workspace, &config)? {
+                    eprintln!("{}", "Aborted.".red());
                     return Ok(());
                 }
             }
@@ -523,6 +543,7 @@ async fn main() -> Result<()> {
                 &state.api_key,
                 command,
                 args,
+                interactive,
             )?;
         }
         Some(Command::Commands { action }) => {

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -252,7 +252,7 @@ pub async fn ensure_shared_server(config: &AppConfig) -> Result<()> {
     // Wait briefly for server to start
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    println!(
+    eprintln!(
         "{} (PID {}, port {})",
         "Shared server started.".green(),
         pid,
@@ -329,7 +329,7 @@ pub async fn check_server_version() -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("Missing version field in server response"))?;
 
     if is_newer_version(server_version, CLI_VERSION) {
-        println!(
+        eprintln!(
             "{} Server is v{}, CLI is v{}. Finish active ai-pod sessions so a new server can start.",
             "Version mismatch:".yellow().bold(),
             server_version,

--- a/src/update.rs
+++ b/src/update.rs
@@ -51,7 +51,7 @@ pub async fn run_update() -> Result<()> {
 pub async fn check_for_update() {
     if let Ok(latest) = fetch_latest_version().await {
         if is_newer(&latest, CURRENT_VERSION) {
-            println!(
+            eprintln!(
                 "{} {} → {} — {}",
                 "Update available:".yellow().bold(),
                 CURRENT_VERSION.dimmed(),

--- a/website/index.html
+++ b/website/index.html
@@ -1005,7 +1005,6 @@ RUN npm install -g @my-org/mcp-server</pre>
       <span class="string">"command"</span>: <span class="string">"ai-pod"</span>,
       <span class="string">"args"</span>: [
         <span class="string">"--no-credential-check"</span>,
-        <span class="string">"--workdir"</span>, <span class="string">"/abs/path/to/workspace"</span>,
         <span class="string">"run"</span>, <span class="string">"claude-code-acp"</span>
       ]
     }

--- a/website/index.html
+++ b/website/index.html
@@ -584,6 +584,7 @@
                 <li><a href="#get-started">Get started</a></li>
                 <li><a href="#how-it-works">How it works</a></li>
                 <li><a href="#usage">Usage</a></li>
+                <li><a href="#ide">IDE</a></li>
                 <li><a href="#security">Security</a></li>
                 <li><a href="#troubleshooting">Troubleshooting</a></li>
             </ul>
@@ -971,6 +972,65 @@ RUN npx playwright install --with-deps
 RUN npm install -g @my-org/mcp-server</pre>
                     </div>
                 </div>
+            </div>
+        </section>
+
+        <hr class="divider" />
+
+        <!-- IDE INTEGRATION -->
+        <section id="ide">
+            <div class="container">
+                <div class="section-label">IDE integration</div>
+                <h2>Plug the in-container agent into your editor</h2>
+                <p class="section-intro">
+                    Any agent inside the container that speaks the
+                    <a href="https://agentclientprotocol.com/">Agent Client Protocol</a>
+                    can drive your IDE through <code>ai-pod run</code>.
+                    Stdio is forwarded transparently; when ai-pod detects
+                    that stdin isn't a terminal it drops the
+                    pseudo-TTY allocation and keeps status output on
+                    stderr, so the JSON-RPC byte stream stays clean.
+                </p>
+
+                <div class="demo-grid">
+                    <div class="code-block">
+                        <div class="code-block-header">
+                            <span class="dot"></span>
+                            Zed — claude-code-acp
+                        </div>
+                        <pre><span class="comment">// ~/.config/zed/settings.json</span>
+{
+  <span class="string">"agent_servers"</span>: {
+    <span class="string">"ai-pod (claude)"</span>: {
+      <span class="string">"command"</span>: <span class="string">"ai-pod"</span>,
+      <span class="string">"args"</span>: [
+        <span class="string">"--no-credential-check"</span>,
+        <span class="string">"--workdir"</span>, <span class="string">"/abs/path/to/workspace"</span>,
+        <span class="string">"run"</span>, <span class="string">"claude-code-acp"</span>
+      ]
+    }
+  }
+}</pre>
+                    </div>
+
+                    <div class="code-block">
+                        <div class="code-block-header">
+                            <span class="dot"></span>
+                            ai-pod.Dockerfile — install ACP adapter
+                        </div>
+                        <pre><span class="comment"># Bake the ACP adapter into the image</span>
+RUN npm install -g @zed-industries/claude-code-acp</pre>
+                    </div>
+                </div>
+
+                <p class="section-intro" style="margin-top: 2rem;">
+                    Run <code>ai-pod</code> interactively once first so the
+                    credential triage and home volume are set up — the
+                    dialog can't run without a TTY. Pass
+                    <code>--no-credential-check</code> from the IDE
+                    afterwards (or keep the workspace clean of
+                    un-triaged sensitive files).
+                </p>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary

Closes #102. Makes `ai-pod run <command>` usable as the launch command an IDE configures for an in-container ACP agent (Claude Code, OpenCode, …) without forking a new subcommand or hard-coding agent-specific glue.

- Detect non-TTY stdin (`libc::isatty(0)`); when piped, the `podman/docker run` flags switch from `-it` to `-i` so no pseudo-TTY is allocated and the in-container agent's stdout stays a clean byte stream the IDE can parse as JSON-RPC.
- Status messages on the run/launch path (`Workspace:`, `Initialising home volume:`, `Starting container:`, `Building container image…`, the update-available banner, etc.) now go to stderr unconditionally. TTY users see no visible difference; non-TTY callers no longer get those lines mixed into stdout.
- Startup update check is skipped when stdin isn't a TTY — avoids a 3 s blocking delay every time the IDE spawns the agent.
- In `Run` with no TTY, the credentials dialog can't run, so ai-pod silently checks for un-triaged files and either proceeds or bails with a clear message pointing at `--no-credential-check` / running `ai-pod` interactively once. The dialoguer prompt itself is reserved for the TTY case.
- README gains an "IDE integration via ACP" section with a Zed config example, and the website gets an `#ide` section pointing at `agentclientprotocol.com`.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (183 unit + 16 integration + 1 rate-limit, all pass)
- [x] `cargo clippy --all-targets` (no new warnings)
- [ ] Manual smoke from an IDE: configure Zed `agent_servers` with `ai-pod --no-credential-check --workdir … run claude-code-acp`, install `@zed-industries/claude-code-acp` in `ai-pod.Dockerfile`, verify session starts and tool calls round-trip.

https://claude.ai/code/session_01FDDrStjUCKUJkeuJAzr7t9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDDrStjUCKUJkeuJAzr7t9)_