### PR TITLE
Let users pick the container runtime, persisted per session

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,10 @@ pub struct Cli {
     /// Print podman/docker commands instead of executing them
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Container runtime to use (overrides AI_POD_RUNTIME and autodetect)
+    #[arg(long, value_enum)]
+    pub runtime: Option<crate::runtime::RuntimeKind>,
 }
 
 #[derive(Subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,6 +104,55 @@ impl GlobalConfig {
     }
 }
 
+/// Path to a per-session record, relative to the config dir. Kept in a
+/// `sessions/` subdirectory so the server's project scanner (which treats every
+/// top-level `~/.ai-pod/*.json` stem as a project) never picks these up.
+pub fn session_state_path(config_dir: &Path, session_id: &str) -> PathBuf {
+    config_dir.join("sessions").join(format!("{session_id}.json"))
+}
+
+/// Per-session state persisted to `~/.ai-pod/sessions/{session_id}.json`. The
+/// host-side CLI writes this at container launch; the shared server reads it
+/// (keyed by the `X-Ai-Pod-Session-Id` header) to run service containers on the
+/// same runtime the session was launched with.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SessionState {
+    pub runtime: crate::runtime::RuntimeKind,
+}
+
+impl SessionState {
+    /// Load a session record straight from a config dir. Returns `None` when the
+    /// file is missing or malformed, so callers can fall back gracefully.
+    pub fn load_from_dir(config_dir: &Path, session_id: &str) -> Option<Self> {
+        let path = session_state_path(config_dir, session_id);
+        let raw = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    /// Persist this record to `~/.ai-pod/sessions/{session_id}.json` at 0o600,
+    /// creating the `sessions/` directory if needed. Atomic via temp + rename.
+    pub fn save(&self, config: &AppConfig, session_id: &str) -> Result<()> {
+        let dir = config.sessions_dir();
+        std::fs::create_dir_all(&dir).context("Failed to create ~/.ai-pod/sessions/")?;
+        let path = dir.join(format!("{session_id}.json"));
+        let json = serde_json::to_string_pretty(self)?;
+        let tmp = path.with_extension("tmp");
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)
+            .context("Failed to write session state")?;
+        file.write_all(json.as_bytes())
+            .context("Failed to write session state contents")?;
+        std::fs::rename(&tmp, &path).context("Failed to rename session state")?;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .context("Failed to set permissions on session state")?;
+        Ok(())
+    }
+}
+
 impl AppConfig {
     pub fn new() -> Result<Self> {
         let home_dir = dirs::home_dir().context("Could not determine home directory")?;
@@ -129,6 +178,16 @@ impl AppConfig {
     /// Returns path to the shared server state file: ~/.ai-pod/server.json
     pub fn server_state_file(&self) -> PathBuf {
         self.config_dir.join("server.json")
+    }
+
+    /// Directory holding per-session records: ~/.ai-pod/sessions/
+    pub fn sessions_dir(&self) -> PathBuf {
+        self.config_dir.join("sessions")
+    }
+
+    /// Returns path to a per-session record: ~/.ai-pod/sessions/{session_id}.json
+    pub fn session_state_file(&self, session_id: &str) -> PathBuf {
+        session_state_path(&self.config_dir, session_id)
     }
 
     pub fn claude_settings_path(&self) -> PathBuf {
@@ -208,6 +267,47 @@ mod tests {
         let p = config.server_state_file();
         assert!(p.starts_with(&config.config_dir));
         assert!(p.to_string_lossy().ends_with("server.json"));
+    }
+
+    #[test]
+    fn session_state_file_is_under_sessions_subdir() {
+        let dir = TempDir::new().unwrap();
+        let config = temp_config(&dir);
+        let p = config.session_state_file("abc123");
+        assert!(p.starts_with(config.sessions_dir()));
+        assert!(p.to_string_lossy().ends_with("abc123.json"));
+        // Must NOT sit directly under config_dir, or the server's project
+        // scanner would mistake it for a project state file.
+        assert_ne!(p.parent(), Some(config.config_dir.as_path()));
+    }
+
+    #[test]
+    fn session_state_round_trips_at_0o600() {
+        use crate::runtime::RuntimeKind;
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let config = temp_config(&dir);
+        config.init().unwrap();
+
+        SessionState {
+            runtime: RuntimeKind::Docker,
+        }
+        .save(&config, "sess0001")
+        .unwrap();
+
+        let path = config.session_state_file("sess0001");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        let loaded = SessionState::load_from_dir(&config.config_dir, "sess0001").unwrap();
+        assert_eq!(loaded.runtime, RuntimeKind::Docker);
+    }
+
+    #[test]
+    fn session_state_load_missing_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let config = temp_config(&dir);
+        assert!(SessionState::load_from_dir(&config.config_dir, "nope").is_none());
     }
 
     #[test]

--- a/src/container.rs
+++ b/src/container.rs
@@ -669,6 +669,10 @@ pub fn launch_container(
     let container_name = container_name_for(workspace, &session_id);
     println!("{} {}", "Starting container:".blue().bold(), container_name);
 
+    // Record the runtime for this session before the container starts, so the
+    // shared server runs service containers on the same runtime.
+    crate::config::SessionState { runtime: rt.kind }.save(config, &session_id)?;
+
     refresh_claude_mcp_in_volume(
         rt,
         config,
@@ -748,6 +752,7 @@ pub fn launch_container(
     // agent started for this session. Best-effort: this is also covered by the
     // server's periodic orphan sweep if the CLI was killed.
     crate::service::cleanup_services_for_session(rt, &session_id);
+    let _ = std::fs::remove_file(config.session_state_file(&session_id));
     let _ = run_status;
 
     Ok(())
@@ -767,6 +772,10 @@ pub fn run_in_container(
     let container_name = container_name_for(workspace, &session_id);
     let volume_name = gen_volume_name(workspace);
     let workspace_str = workspace.to_string_lossy();
+
+    // Record the runtime for this session before the container starts, so the
+    // shared server runs service containers on the same runtime.
+    crate::config::SessionState { runtime: rt.kind }.save(config, &session_id)?;
 
     // Init home volume if it doesn't exist
     if !volume_exists(rt, &volume_name)? {
@@ -859,6 +868,7 @@ pub fn run_in_container(
         .context("Failed to run command in container")?;
 
     crate::service::cleanup_services_for_session(rt, &session_id);
+    let _ = std::fs::remove_file(config.session_state_file(&session_id));
 
     if !status.success() {
         anyhow::bail!("Command exited with non-zero status");

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,8 +393,14 @@ async fn main() -> Result<()> {
         _ => {}
     }
 
-    // Detect container runtime (podman preferred, docker fallback)
-    let rt = ContainerRuntime::detect(cli.dry_run)?;
+    // Resolve the runtime preference: --runtime flag > AI_POD_RUNTIME env >
+    // autodetect (podman preferred, docker fallback).
+    let runtime_pref = cli.runtime.or_else(|| {
+        std::env::var("AI_POD_RUNTIME")
+            .ok()
+            .and_then(|v| crate::runtime::RuntimeKind::from_value(&v))
+    });
+    let rt = ContainerRuntime::detect(runtime_pref, cli.dry_run)?;
 
     match &cli.command {
         Some(Command::Build) => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,10 +1,51 @@
 use anyhow::Result;
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 use std::process::Command;
+use std::str::FromStr;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum RuntimeKind {
     Podman,
     Docker,
+}
+
+impl RuntimeKind {
+    /// Stable string form. Matches the binary name and is the single source of
+    /// truth for the CLI flag, the `AI_POD_RUNTIME` env var, and persisted
+    /// session records.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RuntimeKind::Podman => "podman",
+            RuntimeKind::Docker => "docker",
+        }
+    }
+
+    /// Parse from a user/config string. Case-insensitive, trims whitespace;
+    /// returns `None` for anything unrecognized.
+    pub fn from_value(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "podman" => Some(RuntimeKind::Podman),
+            "docker" => Some(RuntimeKind::Docker),
+            _ => None,
+        }
+    }
+
+    /// Whether this runtime's binary is present and runnable on PATH.
+    pub fn is_available(self) -> bool {
+        Command::new(self.as_str())
+            .arg("--version")
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+}
+
+impl FromStr for RuntimeKind {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_value(s).ok_or_else(|| format!("unknown runtime: {s}"))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -14,24 +55,29 @@ pub struct ContainerRuntime {
 }
 
 impl ContainerRuntime {
-    /// Detect which container runtime is available.
-    /// Prefers podman; falls back to docker.
-    pub fn detect(dry_run: bool) -> Result<Self> {
-        if Command::new("podman")
-            .arg("--version")
-            .output()
-            .is_ok_and(|o| o.status.success())
-        {
+    /// Select the container runtime. When `preferred` is set (resolved from the
+    /// `--runtime` flag or `AI_POD_RUNTIME` env), that runtime is used and must
+    /// be available. When `None`, autodetect: prefer podman, fall back to
+    /// docker. Under `dry_run` the availability check is skipped so commands can
+    /// be printed on a host without the chosen runtime installed.
+    pub fn detect(preferred: Option<RuntimeKind>, dry_run: bool) -> Result<Self> {
+        if let Some(kind) = preferred {
+            if dry_run || kind.is_available() {
+                return Ok(Self { kind, dry_run });
+            }
+            anyhow::bail!(
+                "Requested container runtime `{}` is not available on PATH. \
+                 Install it or choose the other runtime.",
+                kind.as_str()
+            );
+        }
+        if RuntimeKind::Podman.is_available() {
             return Ok(Self {
                 kind: RuntimeKind::Podman,
                 dry_run,
             });
         }
-        if Command::new("docker")
-            .arg("--version")
-            .output()
-            .is_ok_and(|o| o.status.success())
-        {
+        if RuntimeKind::Docker.is_available() {
             return Ok(Self {
                 kind: RuntimeKind::Docker,
                 dry_run,
@@ -44,10 +90,7 @@ impl ContainerRuntime {
 
     /// The binary name: "podman" or "docker"
     pub fn cmd(&self) -> &'static str {
-        match self.kind {
-            RuntimeKind::Podman => "podman",
-            RuntimeKind::Docker => "docker",
-        }
+        self.kind.as_str()
     }
 
     /// Returns a std::process::Command with the runtime binary.
@@ -169,5 +212,60 @@ mod tests {
         };
         let program = rt.command().get_program().to_string_lossy().into_owned();
         assert_eq!(program, "echo");
+    }
+
+    #[test]
+    fn from_value_parses_case_insensitively_and_trims() {
+        assert_eq!(RuntimeKind::from_value("podman"), Some(RuntimeKind::Podman));
+        assert_eq!(RuntimeKind::from_value("Docker"), Some(RuntimeKind::Docker));
+        assert_eq!(
+            RuntimeKind::from_value("  PODMAN \n"),
+            Some(RuntimeKind::Podman)
+        );
+        assert_eq!(RuntimeKind::from_value("containerd"), None);
+        assert_eq!(RuntimeKind::from_value(""), None);
+    }
+
+    #[test]
+    fn as_str_round_trips_through_from_value() {
+        for kind in [RuntimeKind::Podman, RuntimeKind::Docker] {
+            assert_eq!(RuntimeKind::from_value(kind.as_str()), Some(kind));
+        }
+    }
+
+    #[test]
+    fn serde_serializes_as_lowercase_binary_name() {
+        assert_eq!(
+            serde_json::to_string(&RuntimeKind::Podman).unwrap(),
+            "\"podman\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RuntimeKind::Docker).unwrap(),
+            "\"docker\""
+        );
+        let parsed: RuntimeKind = serde_json::from_str("\"docker\"").unwrap();
+        assert_eq!(parsed, RuntimeKind::Docker);
+    }
+
+    #[test]
+    fn clap_value_variants_match_string_form() {
+        // The flag value and the persisted/serde string must be identical so a
+        // `--runtime` choice and a stored session record agree.
+        for kind in [RuntimeKind::Podman, RuntimeKind::Docker] {
+            let pv = kind.to_possible_value().unwrap();
+            assert_eq!(pv.get_name(), kind.as_str());
+        }
+    }
+
+    #[test]
+    fn detect_honors_explicit_preference_in_dry_run() {
+        // dry_run skips the availability probe, so an explicit choice is
+        // returned verbatim regardless of what is installed on the host.
+        let rt = ContainerRuntime::detect(Some(RuntimeKind::Docker), true).unwrap();
+        assert_eq!(rt.kind, RuntimeKind::Docker);
+        assert!(rt.dry_run);
+
+        let rt = ContainerRuntime::detect(Some(RuntimeKind::Podman), true).unwrap();
+        assert_eq!(rt.kind, RuntimeKind::Podman);
     }
 }

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -40,6 +40,21 @@ fn extract_session_id(headers: &HeaderMap) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Resolve the container runtime for a session. The launching CLI records it in
+/// `~/.ai-pod/sessions/{session_id}.json`; we read it so service containers run
+/// on the same runtime the session was launched with. Falls back to the
+/// server's own runtime for sessions launched before this existed (or host-side
+/// callers with no session record).
+fn session_runtime(state: &AppState, session_id: &str) -> ContainerRuntime {
+    match crate::config::SessionState::load_from_dir(&state.config_dir, session_id) {
+        Some(s) => ContainerRuntime {
+            kind: s.runtime,
+            dry_run: state.runtime.dry_run,
+        },
+        None => state.runtime.clone(),
+    }
+}
+
 fn rpc_error(id: Value, code: i64, message: &str) -> Value {
     json!({
         "jsonrpc": "2.0",
@@ -224,8 +239,9 @@ pub async fn mcp_handler(
                 }
             };
             let session_id = extract_session_id(&headers).unwrap_or_else(|| "host".to_string());
+            let rt = session_runtime(&state, &session_id);
 
-            let result = handle_tool_call(&state, &workspace, &session_id, &params).await;
+            let result = handle_tool_call(&state, &rt, &workspace, &session_id, &params).await;
             Json(rpc_result(id, result)).into_response()
         }
         _ => {
@@ -240,6 +256,7 @@ pub async fn mcp_handler(
 
 async fn handle_start_service(
     state: &AppState,
+    rt: &ContainerRuntime,
     workspace: &std::path::Path,
     session_id: &str,
     args: &Value,
@@ -307,7 +324,7 @@ async fn handle_start_service(
         commands::ApprovalOutcome::Approved | commands::ApprovalOutcome::AlwaysAllow => {}
     }
 
-    let rt = state.runtime.clone();
+    let rt = rt.clone();
     let workspace_owned = workspace.to_path_buf();
     let session_owned = session_id.to_string();
     let join = tokio::task::spawn_blocking(move || {
@@ -337,7 +354,7 @@ async fn handle_start_service(
 }
 
 async fn handle_stop_service(
-    state: &AppState,
+    rt: &ContainerRuntime,
     workspace: &std::path::Path,
     session_id: &str,
     args: &Value,
@@ -349,7 +366,7 @@ async fn handle_stop_service(
     if let Err(e) = validate_service_name(&name) {
         return tool_error(e);
     }
-    let rt = state.runtime.clone();
+    let rt = rt.clone();
     let workspace_owned = workspace.to_path_buf();
     let session_owned = session_id.to_string();
     let join = tokio::task::spawn_blocking(move || {
@@ -368,11 +385,11 @@ async fn handle_stop_service(
 }
 
 async fn handle_list_services(
-    state: &AppState,
+    rt: &ContainerRuntime,
     workspace: &std::path::Path,
     session_id: &str,
 ) -> Value {
-    let rt = state.runtime.clone();
+    let rt = rt.clone();
     let workspace_owned = workspace.to_path_buf();
     let session_owned = session_id.to_string();
     let join = tokio::task::spawn_blocking(move || {
@@ -394,7 +411,7 @@ async fn handle_list_services(
 }
 
 async fn handle_service_logs(
-    state: &AppState,
+    rt: &ContainerRuntime,
     workspace: &std::path::Path,
     session_id: &str,
     args: &Value,
@@ -411,7 +428,7 @@ async fn handle_service_logs(
         .and_then(|v| v.as_u64())
         .map(|n| n as usize)
         .unwrap_or(50);
-    let rt = state.runtime.clone();
+    let rt = rt.clone();
     let workspace_owned = workspace.to_path_buf();
     let session_owned = session_id.to_string();
     let join = tokio::task::spawn_blocking(move || {
@@ -440,11 +457,57 @@ mod tests {
     use super::*;
     use crate::runtime::RuntimeKind;
 
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
     fn test_runtime(kind: RuntimeKind) -> ContainerRuntime {
         ContainerRuntime {
             kind,
             dry_run: false,
         }
+    }
+
+    fn test_state(config_dir: std::path::PathBuf, kind: RuntimeKind) -> AppState {
+        AppState {
+            projects: Arc::new(Mutex::new(HashMap::new())),
+            config_dir,
+            approval_lock: Arc::new(Mutex::new(())),
+            commands: Arc::new(Mutex::new(HashMap::new())),
+            runtime: test_runtime(kind),
+            keep_alive_until: Arc::new(Mutex::new(
+                std::time::Instant::now() + std::time::Duration::from_secs(30),
+            )),
+        }
+    }
+
+    #[test]
+    fn session_runtime_falls_back_to_server_runtime_when_no_record() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let state = test_state(dir.path().to_path_buf(), RuntimeKind::Podman);
+        // No session file written → falls back to the server's boot runtime.
+        assert_eq!(session_runtime(&state, "missing").kind, RuntimeKind::Podman);
+    }
+
+    #[test]
+    fn session_runtime_reads_persisted_kind_and_keeps_dry_run() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = crate::config::AppConfig {
+            config_dir: dir.path().to_path_buf(),
+            runtime_settings: dir.path().join("runtime-settings.json"),
+            home_dir: dir.path().to_path_buf(),
+        };
+        crate::config::SessionState {
+            runtime: RuntimeKind::Docker,
+        }
+        .save(&config, "sess42")
+        .unwrap();
+
+        // Server runtime is podman, but the session was launched with docker.
+        let state = test_state(dir.path().to_path_buf(), RuntimeKind::Podman);
+        let rt = session_runtime(&state, "sess42");
+        assert_eq!(rt.kind, RuntimeKind::Docker);
+        assert_eq!(rt.dry_run, state.runtime.dry_run);
     }
 
     #[test]
@@ -552,6 +615,7 @@ mod tests {
 
 async fn handle_tool_call(
     state: &AppState,
+    rt: &ContainerRuntime,
     workspace: &std::path::Path,
     session_id: &str,
     params: &Value,
@@ -668,10 +732,10 @@ async fn handle_tool_call(
                 "structuredContent": { "commands": cmds },
             })
         }
-        "start_service" => handle_start_service(state, workspace, session_id, &args).await,
-        "stop_service" => handle_stop_service(state, workspace, session_id, &args).await,
-        "list_services" => handle_list_services(state, workspace, session_id).await,
-        "service_logs" => handle_service_logs(state, workspace, session_id, &args).await,
+        "start_service" => handle_start_service(state, rt, workspace, session_id, &args).await,
+        "stop_service" => handle_stop_service(rt, workspace, session_id, &args).await,
+        "list_services" => handle_list_services(rt, workspace, session_id).await,
+        "service_logs" => handle_service_logs(rt, workspace, session_id, &args).await,
         other => tool_error(format!("Unknown tool: {other}")),
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -183,6 +183,26 @@ pub fn build_app(state: AppState) -> Router {
         .with_state(state)
 }
 
+/// Container runtimes whose binary is currently on PATH. Sessions may be
+/// launched with different runtimes (the choice is persisted per session), so
+/// the orphan sweep must cover every installed runtime rather than only the
+/// server's own boot-time one.
+fn available_runtimes(dry_run: bool) -> Vec<ContainerRuntime> {
+    use crate::runtime::RuntimeKind;
+    [RuntimeKind::Podman, RuntimeKind::Docker]
+        .into_iter()
+        .filter(|k| dry_run || k.is_available())
+        .map(|kind| ContainerRuntime { kind, dry_run })
+        .collect()
+}
+
+/// Sweep orphaned service containers across every installed runtime.
+async fn sweep_orphan_services(base: &ContainerRuntime) {
+    for rt in available_runtimes(base.dry_run) {
+        sweep_orphan_services_one(&rt).await;
+    }
+}
+
 /// Find live `ai-pod-parent={session_id}` labels whose corresponding main
 /// container is no longer running and remove the service containers tied to
 /// them.
@@ -191,7 +211,7 @@ pub fn build_app(state: AppState) -> Router {
 /// inside, commas between entries). This is distinct from `inspect --format
 /// "{{.Config.Labels}}"`, which uses Go's `map[k:v]` rendering with colons —
 /// don't reuse this parser for inspect output.
-async fn sweep_orphan_services(rt: &ContainerRuntime) {
+async fn sweep_orphan_services_one(rt: &ContainerRuntime) {
     // Set of session ids currently backed by a live main container.
     let main_output = rt
         .async_command()

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -26,7 +26,7 @@ lazy_static! {
     /// `None` means no runtime is available on this machine; tests that
     /// require one skip via `try_runtime()`.
     static ref RT: Option<Mutex<ContainerRuntime>> = {
-        let rt = ContainerRuntime::detect(false).ok()?;
+        let rt = ContainerRuntime::detect(None, false).ok()?;
         // detect() only checks `--version`; probe `info` to confirm the
         // daemon is actually running.
         let ok = rt


### PR DESCRIPTION
Closes #106.

## What

Lets users explicitly choose podman vs docker when both are installed, and makes that choice flow all the way through to the service containers the shared server starts.

## Why

`ContainerRuntime::detect()` only autodetected (podman-first). Issue #106 asks for an explicit override. The subtle part: the **shared server is a separate process** (`ai-pod serve`) that froze its runtime at boot, so a per-launch `--runtime` choice would never reach the `start_service` path — service containers could run on the wrong runtime, breaking the per-workspace network they must share with the main container.

## How

- **Selection** — new `--runtime <podman|docker>` flag and `AI_POD_RUNTIME` env var. Precedence: **flag > env > autodetect**. An explicit choice that isn't on `PATH` now fails with a clear message (`src/runtime.rs`, `src/cli.rs`, `src/main.rs`).
- **Per-session persistence** — instead of a runtime-wide setting, the launching CLI records the chosen runtime in `~/.ai-pod/sessions/{session_id}.json`. The server reads it back keyed by the `X-Ai-Pod-Session-Id` header it already receives, and uses it for `start_service`/`stop_service`/`list_services`/`service_logs`, falling back to its own boot runtime when no record exists (older/host-side sessions). Records live in a `sessions/` subdirectory so the server's project scanner never mistakes them for project state files (`src/config.rs`, `src/container.rs`, `src/server/mcp.rs`).
- **Dual-runtime sweep** — the periodic orphan sweep now reaps service containers across **both** podman and docker, since concurrent sessions may use different runtimes (`src/server/mod.rs`).

## Notes / scope

- No new MCP header and no agent cooperation needed — the runtime travels via the on-disk session record the server already can key by session id.
- The spawned `serve` process's own boot runtime is still autodetect (or inherited `AI_POD_RUNTIME`); it only matters as a fallback and for the keep-alive check. Service routing is per-session; the sweep covers both runtimes.
- Backward compatible: sessions launched before this change have no record and fall back to the boot runtime exactly as today.

## Tests

- `RuntimeKind` parse/serde/clap round-trips; `detect()` honors an explicit preference under dry-run.
- `SessionState` save→load round-trip at `0o600`, lands under `sessions/`, missing→`None`.
- `session_runtime` falls back to the server runtime with no record and reads the persisted kind (preserving `dry_run`) when present.
- All existing unit + e2e tests pass (`cargo test`: 215 passing).

https://claude.ai/code/session_013FvQA3av4wtiehPUnKDxgx

---
_Generated by [Claude Code](https://claude.ai/code/session_013FvQA3av4wtiehPUnKDxgx)_