### PR TITLE
Add OpenAI Codex CLI support as a third agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "toml_edit 0.22.27",
  "tower",
  "tower_governor",
  "uuid",
@@ -2260,7 +2261,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3343,6 +3344,12 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
@@ -3352,12 +3359,24 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
 ]
@@ -3370,6 +3389,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ colored = "3"
 dialoguer = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml_edit = "0.22"
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
 notify-rust = "4"

--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 [Read the docs](https://ai-pod.apps.farbenmeer.de)
 
-**Claude Code & OpenCode inside isolated containers — safe, persistent, and project-aware.**
+**Claude Code, OpenCode & Codex inside isolated containers — safe, persistent, and project-aware.**
 
-ai-pod manages per-workspace containers that run Claude Code or OpenCode. It works with **Podman** (preferred) or **Docker** — whichever is available on your system. Each workspace gets a dedicated container, a shared background server bridges host interaction via MCP, and your personal agent settings follow you everywhere.
+ai-pod manages per-workspace containers that run Claude Code, OpenCode, or OpenAI Codex. It works with **Podman** (preferred) or **Docker** — whichever is available on your system. Each workspace gets a dedicated container, a shared background server bridges host interaction via MCP, and your personal agent settings follow you everywhere.
 
 ---
 
 ## Features
 
 - **Workspace isolation** — each directory gets its own container, named by a hash of its path; projects can't interfere with each other
-- **Persistent agent state** — a named volume preserves `~/.claude` and `~/.config/opencode` (login, memory, settings) across container restarts
+- **Persistent agent state** — a named volume preserves `~/.claude`, `~/.config/opencode`, and `~/.codex` (login, memory, settings) across container restarts
 - **Credential scanning** — scans the workspace for secrets before mounting it; prompts you to review or abort
 - **Custom Dockerfiles per project** — drop an `ai-pod.Dockerfile` in any project to install extra runtimes, tools, or MCP servers
 - **AI-driven skill file** — container environment context and host-command usage are delivered via an auto-generated ai-pod skill loaded by Claude and OpenCode
 - **Host command execution via MCP** — the in-container agent talks to the shared host server over MCP (`http://host.containers.internal:7822/mcp`); every host command requires your explicit approval with a persistent allowlist
 - **File-based command output** — every command writes stdout/stderr/exit to `{workspace}/.ai-pod/commands/{session_id}/{command_id}/` so the agent reads long-running output directly
 - **Interactive TUIs** — `ai-pod commands` to inspect/kill running host commands, `ai-pod allowed` to manage the whitelist
-- **Desktop notifications** — Stop hooks notify you on Claude session end, and an OpenCode plugin sends notifications when `session.idle` fires
+- **Desktop notifications** — Stop hooks notify you on Claude session end, an OpenCode plugin sends notifications when `session.idle` fires, and Codex's `notify` program fires on turn completion
 - **Transparent host networking** — containers reach host services at `host.containers.internal` (Podman) or `host.docker.internal` (Docker); no manual port mapping needed
 - **Auto-update checks** — silently checks for new releases on startup and notifies you when one is available
 
@@ -153,7 +153,7 @@ launch; a warning is printed if a container is currently running.
 
 Your host `~/.claude/CLAUDE.md` and `~/.claude/settings.json` are merged with container defaults at launch time, and your `~/.claude.json` is copied in on first init, so your personal Claude preferences carry over automatically.
 
-The MCP server entry for ai-pod is written into `~/.claude.json` (`mcpServers.ai-pod`) and injected into OpenCode via the `OPENCODE_CONFIG_CONTENT` env var, both with the per-session credentials baked in literally — no env-var interpolation, so `claude doctor` stays clean.
+The MCP server entry for ai-pod is written into `~/.claude.json` (`mcpServers.ai-pod`), injected into OpenCode via the `OPENCODE_CONFIG_CONTENT` env var, and merged into Codex's `~/.codex/config.toml` (`[mcp_servers.ai-pod]`, a streamable-HTTP MCP server), all with the per-session credentials baked in literally — no env-var interpolation, so `claude doctor` stays clean. Your personal Codex login (`~/.codex/auth.json`) and other `config.toml` preferences (model, provider) carry over and are preserved; ai-pod only rewrites the keys it owns.
 
 ---
 
@@ -169,7 +169,7 @@ ai-pod init
 
 This writes an `ai-pod.Dockerfile` to the workspace root based on the default image. Edit it to add anything your project needs (e.g. Node, Python, Playwright, project-specific MCP servers). When `ai-pod` launches, it automatically uses `ai-pod.Dockerfile` if present, otherwise falls back to the global default.
 
-The default image is based on Ubuntu. The Dockerfile downloads the agent (Claude Code or OpenCode) via `curl http://${HOST_GATEWAY}:7822/install/{agent}.sh` — the shared host server vends per-agent install scripts. The generated Dockerfile includes commented-out examples for common additions like Playwright and MCP servers.
+The default image is based on Ubuntu. The Dockerfile downloads the agent (Claude Code, OpenCode, or Codex) via `curl http://${HOST_GATEWAY}:7822/install/{agent}.sh` — the shared host server vends per-agent install scripts. The generated Dockerfile includes commented-out examples for common additions like Playwright and MCP servers.
 
 ---
 

--- a/ai-pod.Dockerfile
+++ b/ai-pod.Dockerfile
@@ -6,6 +6,7 @@ ARG HOST_GATEWAY
 ARG AI_POD_VERSION
 RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/claude.sh" | bash
 RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/opencode.sh" | bash
+RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/codex.sh" | bash
 
 WORKDIR /app
 
@@ -19,5 +20,6 @@ USER ai-pod
 
 ENV PATH="/home/ai-pod/.local/bin:${PATH}"
 ENV EDITOR=vim
+ENV OPENCODE_YOLO=1
 
 CMD ["claude"]

--- a/ai-pod.Dockerfile
+++ b/ai-pod.Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:latest
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git vim gh && rm -rf /var/lib/apt/lists/*
 
 ARG HOST_GATEWAY
 ARG AI_POD_VERSION

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 pub enum Agent {
     Claude,
     Opencode,
+    Codex,
 }
 
 #[derive(ValueEnum, Clone, Debug, PartialEq)]
@@ -17,7 +18,7 @@ pub enum BaseImage {
 }
 
 #[derive(Parser)]
-#[command(name = "ai-pod", about = "Run Claude Code inside Podman containers", version)]
+#[command(name = "ai-pod", about = "Run AI coding agents inside Podman containers", version)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -198,6 +198,18 @@ impl AppConfig {
         self.home_dir.join(".claude").join("CLAUDE.md")
     }
 
+    pub fn codex_dir(&self) -> PathBuf {
+        self.home_dir.join(".codex")
+    }
+
+    pub fn codex_config_path(&self) -> PathBuf {
+        self.codex_dir().join("config.toml")
+    }
+
+    pub fn codex_auth_path(&self) -> PathBuf {
+        self.codex_dir().join("auth.json")
+    }
+
     /// Returns the directory for storing moved credential files for a given workspace.
     /// E.g., `/home/user/my-project` → `~/.env-files/home-user-my-project/`
     pub fn env_files_project_dir(&self, workspace: &Path) -> PathBuf {
@@ -326,6 +338,19 @@ mod tests {
         let p = config.claude_md_path();
         assert!(p.ends_with("CLAUDE.md"));
         assert!(p.to_string_lossy().contains(".claude"));
+    }
+
+    #[test]
+    fn codex_paths_point_under_codex_dir() {
+        let dir = TempDir::new().unwrap();
+        let config = temp_config(&dir);
+        assert!(config.codex_dir().ends_with(".codex"));
+        let cfg = config.codex_config_path();
+        assert!(cfg.starts_with(config.codex_dir()));
+        assert!(cfg.ends_with("config.toml"));
+        let auth = config.codex_auth_path();
+        assert!(auth.starts_with(config.codex_dir()));
+        assert!(auth.ends_with("auth.json"));
     }
 
     #[test]

--- a/src/container.rs
+++ b/src/container.rs
@@ -325,6 +325,48 @@ fn opencode_config_content(server_url: &str, api_key: &str, session_id: &str) ->
     .expect("serialize opencode config content")
 }
 
+/// Merge ai-pod's keys into a Codex `config.toml`, preserving everything else.
+///
+/// Codex reads `~/.codex/config.toml` (TOML); login/auth lives separately in
+/// `~/.codex/auth.json` and is never touched here. We use `toml_edit` so a
+/// user's persisted, possibly hand-edited config (model, provider, comments,
+/// other `[mcp_servers.*]`) survives byte-for-byte — only the five keys we own
+/// are rewritten on every launch:
+///   - `experimental_use_rmcp_client` (enables native streamable-HTTP MCP)
+///   - `[mcp_servers.ai-pod]` (url + http_headers, with literal session creds)
+///   - `approval_policy = "never"` and `sandbox_mode = "danger-full-access"`
+///     (the container is the sandbox, matching Claude's `bypassPermissions`
+///     and OpenCode's YOLO mode; a user's stricter value is intentionally
+///     overridden each launch)
+///   - `notify` (points at the in-container notify helper)
+fn codex_config_merge(
+    existing: &str,
+    server_url: &str,
+    api_key: &str,
+    session_id: &str,
+) -> String {
+    // Missing OR unparsable config -> start from an empty document.
+    let mut doc = existing
+        .parse::<toml_edit::DocumentMut>()
+        .unwrap_or_default();
+
+    doc["experimental_use_rmcp_client"] = toml_edit::value(true);
+    doc["approval_policy"] = toml_edit::value("never");
+    doc["sandbox_mode"] = toml_edit::value("danger-full-access");
+
+    let mut notify = toml_edit::Array::new();
+    notify.push("/usr/local/bin/ai-pod-codex-notify");
+    doc["notify"] = toml_edit::value(notify);
+
+    // Nested tables auto-vivify, so this works on an empty document too.
+    let server = &mut doc["mcp_servers"]["ai-pod"];
+    server["url"] = toml_edit::value(format!("{}/mcp", server_url));
+    server["http_headers"]["X-Api-Key"] = toml_edit::value(api_key);
+    server["http_headers"]["X-Ai-Pod-Session-Id"] = toml_edit::value(session_id);
+
+    doc.to_string()
+}
+
 fn read_git_global(key: &str) -> Option<String> {
     std::process::Command::new("git")
         .args(["config", "--global", key])
@@ -427,6 +469,7 @@ fn seed_home_volume(
             "mkdir",
             "-p",
             &format!("{}/.claude", CONTAINER_HOME),
+            &format!("{}/.codex", CONTAINER_HOME),
             &format!("{}/.config", CONTAINER_HOME),
             &format!("{}/.config/opencode/plugins", CONTAINER_HOME),
         ])
@@ -469,6 +512,25 @@ fn seed_home_volume(
                 ),
             ])
             .status();
+    }
+
+    // First-time init only: carry the host's Codex login + prefs into the
+    // volume so the user starts logged in. `refresh_codex_config_in_volume`
+    // later merges ai-pod's keys over the copied config.toml. Auth lives in
+    // auth.json and is preserved untouched across reseeds.
+    if copy_claude_json {
+        for host_path in [config.codex_auth_path(), config.codex_config_path()] {
+            if host_path.exists() {
+                let _ = rt
+                    .command()
+                    .args([
+                        "cp",
+                        &host_path.to_string_lossy(),
+                        &format!("{}:{}/.codex/", init_container, CONTAINER_HOME),
+                    ])
+                    .status();
+            }
+        }
     }
 
     write_gitconfig_to_volume(rt, config, &init_container)?;
@@ -547,6 +609,70 @@ fn refresh_claude_mcp_in_volume(
             "cp",
             tmp_out.to_str().unwrap(),
             &format!("{}:{}/.claude.json", init_container, CONTAINER_HOME),
+        ])
+        .status();
+
+    let _ = rt.command().args(["rm", &init_container]).status();
+    let _ = std::fs::remove_file(&tmp_in);
+    let _ = std::fs::remove_file(&tmp_out);
+    Ok(())
+}
+
+/// Update the `~/.codex/config.toml` in the volume with ai-pod's MCP entry and
+/// runtime settings (see [`codex_config_merge`]). Runs on every launch so the
+/// in-volume config matches the env the agent will see, mirroring
+/// [`refresh_claude_mcp_in_volume`].
+fn refresh_codex_config_in_volume(
+    rt: &ContainerRuntime,
+    config: &AppConfig,
+    volume_name: &str,
+    container_name: &str,
+    image: &str,
+    server_url: &str,
+    api_key: &str,
+    session_id: &str,
+) -> Result<()> {
+    let init_container = format!("{}-codex", container_name);
+    let status = rt
+        .command()
+        .args([
+            "create",
+            "--name",
+            &init_container,
+            "-v",
+            &format!("{}:{}", volume_name, CONTAINER_HOME),
+            image,
+            "true",
+        ])
+        .status()
+        .context("Failed to create codex-refresh container")?;
+    if !status.success() {
+        anyhow::bail!("Failed to create codex-refresh container");
+    }
+
+    // Pull the existing config.toml out of the volume (may not exist yet).
+    let tmp_in = config.config_dir.join("codex-config-in.toml");
+    let _ = std::fs::remove_file(&tmp_in);
+    let _ = rt
+        .command()
+        .args([
+            "cp",
+            &format!("{}:{}/.codex/config.toml", init_container, CONTAINER_HOME),
+            tmp_in.to_str().unwrap(),
+        ])
+        .status();
+
+    let existing = std::fs::read_to_string(&tmp_in).unwrap_or_default();
+    let merged = codex_config_merge(&existing, server_url, api_key, session_id);
+
+    let tmp_out = config.config_dir.join("codex-config-out.toml");
+    std::fs::write(&tmp_out, merged)?;
+    let _ = rt
+        .command()
+        .args([
+            "cp",
+            tmp_out.to_str().unwrap(),
+            &format!("{}:{}/.codex/config.toml", init_container, CONTAINER_HOME),
         ])
         .status();
 
@@ -686,6 +812,17 @@ pub fn launch_container(
         &session_id,
     )?;
 
+    refresh_codex_config_in_volume(
+        rt,
+        config,
+        &volume_name,
+        &prefix,
+        image,
+        &rt.server_url(),
+        api_key,
+        &session_id,
+    )?;
+
     let add_host = rt.add_host_arg();
     let host_gw_env = format!("HOST_GATEWAY={}", rt.host_gateway());
     let server_url_env = format!("AI_POD_SERVER_URL={}", rt.server_url());
@@ -796,6 +933,17 @@ pub fn run_in_container(
     }
 
     refresh_claude_mcp_in_volume(
+        rt,
+        config,
+        &volume_name,
+        &container_name,
+        image,
+        &rt.server_url(),
+        api_key,
+        &session_id,
+    )?;
+
+    refresh_codex_config_in_volume(
         rt,
         config,
         &volume_name,
@@ -1128,6 +1276,82 @@ mod tests {
         assert_eq!(v["mcp"]["ai-pod"]["enabled"], true);
         assert_eq!(v["mcp"]["ai-pod"]["headers"]["X-Api-Key"], "k1");
         assert_eq!(v["mcp"]["ai-pod"]["headers"]["X-Ai-Pod-Session-Id"], "s2");
+    }
+
+    #[test]
+    fn codex_config_merge_into_empty() {
+        let out = codex_config_merge(
+            "",
+            "http://host.containers.internal:7822",
+            "k1",
+            "s2",
+        );
+        let doc = out.parse::<toml_edit::DocumentMut>().unwrap();
+        assert_eq!(doc["experimental_use_rmcp_client"].as_bool(), Some(true));
+        assert_eq!(doc["approval_policy"].as_str(), Some("never"));
+        assert_eq!(doc["sandbox_mode"].as_str(), Some("danger-full-access"));
+        assert_eq!(
+            doc["notify"].as_array().unwrap().get(0).unwrap().as_str(),
+            Some("/usr/local/bin/ai-pod-codex-notify")
+        );
+        let server = &doc["mcp_servers"]["ai-pod"];
+        assert_eq!(
+            server["url"].as_str(),
+            Some("http://host.containers.internal:7822/mcp")
+        );
+        assert_eq!(server["http_headers"]["X-Api-Key"].as_str(), Some("k1"));
+        assert_eq!(
+            server["http_headers"]["X-Ai-Pod-Session-Id"].as_str(),
+            Some("s2")
+        );
+    }
+
+    #[test]
+    fn codex_config_merge_preserves_existing_keys() {
+        let existing = "model = \"gpt-5\"\n# my comment\n";
+        let out = codex_config_merge(
+            existing,
+            "http://host.containers.internal:7822",
+            "k1",
+            "s2",
+        );
+        // The user's key and comment survive (toml_edit, not a typed rewrite).
+        assert!(out.contains("# my comment"), "comment should survive: {out}");
+        let doc = out.parse::<toml_edit::DocumentMut>().unwrap();
+        assert_eq!(doc["model"].as_str(), Some("gpt-5"));
+        // ...and ai-pod's keys are still merged in.
+        assert_eq!(
+            doc["mcp_servers"]["ai-pod"]["http_headers"]["X-Api-Key"].as_str(),
+            Some("k1")
+        );
+    }
+
+    #[test]
+    fn codex_config_merge_url_uses_runtime_gateway() {
+        // On Docker the gateway is host.docker.internal — the url must reflect
+        // whatever server_url is passed, not a hardcoded host.
+        let out = codex_config_merge("", "http://host.docker.internal:7822", "k1", "s2");
+        let doc = out.parse::<toml_edit::DocumentMut>().unwrap();
+        assert_eq!(
+            doc["mcp_servers"]["ai-pod"]["url"].as_str(),
+            Some("http://host.docker.internal:7822/mcp")
+        );
+    }
+
+    #[test]
+    fn codex_config_merge_overwrites_stale_session() {
+        let first = codex_config_merge("", "http://h:7822", "k1", "old-session");
+        let second = codex_config_merge(&first, "http://h:7822", "k2", "new-session");
+        let doc = second.parse::<toml_edit::DocumentMut>().unwrap();
+        let server = &doc["mcp_servers"]["ai-pod"];
+        assert_eq!(server["http_headers"]["X-Api-Key"].as_str(), Some("k2"));
+        assert_eq!(
+            server["http_headers"]["X-Ai-Pod-Session-Id"].as_str(),
+            Some("new-session")
+        );
+        // No stale session credential left behind.
+        assert!(second.contains("new-session"));
+        assert!(!second.contains("old-session"), "stale session must be gone: {second}");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn resolve_agent(agent: Option<cli::Agent>) -> Result<cli::Agent> {
     match agent {
         Some(a) => Ok(a),
         None => {
-            let items = &["Claude", "OpenCode"];
+            let items = &["Claude", "OpenCode", "Codex"];
             let sel = dialoguer::Select::new()
                 .with_prompt("Select agent")
                 .items(items)
@@ -59,7 +59,8 @@ fn resolve_agent(agent: Option<cli::Agent>) -> Result<cli::Agent> {
                 .context("Selection cancelled")?;
             Ok(match sel {
                 0 => cli::Agent::Claude,
-                _ => cli::Agent::Opencode,
+                1 => cli::Agent::Opencode,
+                _ => cli::Agent::Codex,
             })
         }
     }
@@ -80,7 +81,7 @@ fn resolve_base_image(agent: &cli::Agent, image: Option<cli::BaseImage>) -> Resu
             cli::BaseImage::Rust,
             cli::BaseImage::Python,
         ]),
-        cli::Agent::Claude => (&["Alpine", "Ubuntu", "Node", "Rust", "Python"], &[
+        cli::Agent::Claude | cli::Agent::Codex => (&["Alpine", "Ubuntu", "Node", "Rust", "Python"], &[
             cli::BaseImage::Alpine,
             cli::BaseImage::Ubuntu,
             cli::BaseImage::Node,
@@ -157,6 +158,7 @@ fn init_project(
     let agent_str = match agent {
         cli::Agent::Claude => "claude",
         cli::Agent::Opencode => "opencode",
+        cli::Agent::Codex => "codex",
     };
 
     let cfg = base_image_config(&image);

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,10 +255,17 @@ async fn launch_flow(cli: &Cli, rt: &ContainerRuntime) -> Result<()> {
     //    Dockerfile can fetch /install/{agent}.sh from http://{gateway}:7822)
     server::lifecycle::ensure_shared_server(&config).await?;
 
+    // 5. Check server version compatibility BEFORE building. A stale server
+    //    (e.g. one started by a prior CLI that predates a newly-added agent or
+    //    install route) would serve 404s during the build; bail here with a
+    //    clear "finish active sessions" message instead of producing a broken
+    //    image.
+    server::lifecycle::check_server_version().await?;
+
     // Prune .ai-pod/commands/ entries for sessions whose container is gone.
     clean_stale_sessions(rt, &workspace);
 
-    // 5. Build image if needed
+    // 6. Build image if needed
     let image = image::image_name(&workspace);
     image::ensure_image(rt, &dockerfile, &image, cli.rebuild, cli.no_cache)?;
 
@@ -266,9 +273,6 @@ async fn launch_flow(cli: &Cli, rt: &ContainerRuntime) -> Result<()> {
     // request: re-arm the inactivity timer so the server doesn't shut down
     // while we set up state and launch the container.
     server::lifecycle::bump_keep_alive().await;
-
-    // 6. Check server version compatibility
-    server::lifecycle::check_server_version().await?;
 
     // 7. Get or create project state (stable api_key)
     let project_id = workspace::workspace_hash(&workspace);
@@ -420,6 +424,8 @@ async fn main() -> Result<()> {
                 );
             }
             server::lifecycle::ensure_shared_server(&config).await?;
+            // Catch a stale server before building (see launch_flow for why).
+            server::lifecycle::check_server_version().await?;
             let image = image::image_name(&workspace);
             image::ensure_image(&rt, &dockerfile, &image, cli.rebuild, cli.no_cache)?;
         }
@@ -532,10 +538,11 @@ async fn main() -> Result<()> {
                 }
             }
             server::lifecycle::ensure_shared_server(&config).await?;
+            // Catch a stale server before building (see launch_flow for why).
+            server::lifecycle::check_server_version().await?;
             let image = image::image_name(&workspace);
             image::ensure_image(&rt, &dockerfile, &image, cli.rebuild, cli.no_cache)?;
             server::lifecycle::bump_keep_alive().await;
-            server::lifecycle::check_server_version().await?;
             let project_id = workspace::workspace_hash(&workspace);
             let state = server::lifecycle::get_or_create_project_state(&config, &workspace)?;
             server::lifecycle::reload_config().await?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -58,6 +58,7 @@ async fn version_handler() -> Json<serde_json::Value> {
 
 const INSTALL_CLAUDE_SH: &str = include_str!("../../templates/install-claude.sh");
 const INSTALL_OPENCODE_SH: &str = include_str!("../../templates/install-opencode.sh");
+const INSTALL_CODEX_SH: &str = include_str!("../../templates/install-codex.sh");
 
 /// Stub returned when an outdated `ai-pod.Dockerfile` still tries to fetch
 /// `/host-tools`. The bundled `host-tools` binary was removed in 0.11.0 in
@@ -115,6 +116,7 @@ async fn install_script_handler(AxumPath(name): AxumPath<String>) -> Response {
     let body = match name.as_str() {
         "claude.sh" => INSTALL_CLAUDE_SH,
         "opencode.sh" => INSTALL_OPENCODE_SH,
+        "codex.sh" => INSTALL_CODEX_SH,
         _ => {
             return (StatusCode::NOT_FOUND, "Unknown install script").into_response();
         }

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -4,7 +4,14 @@ FROM {{BASE_IMAGE}}
 {{EXTRA_COMMANDS}}
 ARG HOST_GATEWAY
 ARG AI_POD_VERSION
-RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/{{AGENT}}.sh" | bash
+# Fetch to a file first: `curl ... | bash` masks a failed download because the
+# pipeline's exit status is bash's, not curl's, so a 404 (e.g. an outdated
+# shared server that doesn't know this agent's install route) would silently
+# produce an image without the agent. Splitting the steps lets `curl -f` fail
+# the build loudly instead.
+RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/{{AGENT}}.sh" -o /tmp/ai-pod-install.sh \
+    && bash /tmp/ai-pod-install.sh \
+    && rm -f /tmp/ai-pod-install.sh
 
 WORKDIR /app
 

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -4,14 +4,7 @@ FROM {{BASE_IMAGE}}
 {{EXTRA_COMMANDS}}
 ARG HOST_GATEWAY
 ARG AI_POD_VERSION
-# Fetch to a file first: `curl ... | bash` masks a failed download because the
-# pipeline's exit status is bash's, not curl's, so a 404 (e.g. an outdated
-# shared server that doesn't know this agent's install route) would silently
-# produce an image without the agent. Splitting the steps lets `curl -f` fail
-# the build loudly instead.
-RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/{{AGENT}}.sh" -o /tmp/ai-pod-install.sh \
-    && bash /tmp/ai-pod-install.sh \
-    && rm -f /tmp/ai-pod-install.sh
+RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/{{AGENT}}.sh" | bash
 
 WORKDIR /app
 

--- a/templates/install-codex.sh
+++ b/templates/install-codex.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Installed in-container by the ai-pod Dockerfile via:
+#   curl http://${HOST_GATEWAY}:7822/install/codex.sh | bash
+set -e
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  TRIPLE="x86_64-unknown-linux-musl" ;;
+  aarch64) TRIPLE="aarch64-unknown-linux-musl" ;;
+  *)
+    echo "Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+# The musl-static binary runs on every ai-pod base image (Alpine and glibc alike).
+URL="https://github.com/openai/codex/releases/latest/download/codex-${TRIPLE}.tar.gz"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -fsSL "$URL" -o "$TMPDIR/codex.tar.gz"
+tar -xzf "$TMPDIR/codex.tar.gz" -C "$TMPDIR"
+
+# The release tarball names the binary with the full target triple, not "codex".
+# Glob for it so minor naming/layout changes don't break the install.
+BIN="$(find "$TMPDIR" -maxdepth 2 -name 'codex-*-unknown-linux-musl' -type f | head -n1)"
+if [ -z "$BIN" ]; then
+  echo "Could not locate codex binary in release archive" >&2
+  exit 1
+fi
+install -m 0755 "$BIN" /usr/local/bin/codex
+echo "Installed codex at /usr/local/bin/codex"
+
+# Completion-notification helper invoked by codex's `notify` config option.
+# Codex passes a JSON event as $1; we ignore it and send a generic message,
+# reading the ai-pod credentials from the container env at runtime.
+cat > /usr/local/bin/ai-pod-codex-notify <<'NOTIFY'
+#!/bin/sh
+url="${AI_POD_SERVER_URL%/}"
+[ -n "$url" ] && [ -n "$AI_POD_API_KEY" ] && [ -n "$AI_POD_PROJECT_ID" ] || exit 0
+curl -fsS -X POST \
+  -H "X-Api-Key: $AI_POD_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d "{\"project_id\":\"$AI_POD_PROJECT_ID\",\"message\":\"Codex: Task completed\"}" \
+  "$url/notify_user" >/dev/null 2>&1 || true
+NOTIFY
+chmod 0755 /usr/local/bin/ai-pod-codex-notify
+echo "Installed codex notify helper at /usr/local/bin/ai-pod-codex-notify"

--- a/tests/e2e_agents.sh
+++ b/tests/e2e_agents.sh
@@ -12,6 +12,7 @@ IMAGE="${2:?Usage: e2e_agents.sh <agent> <image>}"
 case "$AGENT" in
   claude)   VERIFY_ARGS="claude --version" ;;
   opencode) VERIFY_ARGS="opencode --version" ;;
+  codex)    VERIFY_ARGS="codex --version" ;;
   *)        echo "Unknown agent: $AGENT"; exit 1 ;;
 esac
 


### PR DESCRIPTION
Closes #109.

Adds **OpenAI Codex CLI** (`codex`) as a third agent alongside Claude Code and OpenCode, following the existing agent-agnostic integration pattern.

## What's included

- **`Agent::Codex` enum + wiring** (`cli.rs`, `main.rs`): interactive selection, `--agent codex`, and `init` writing `CMD ["codex"]`. Codex ships **musl-static** Linux binaries that run on every base image, so all five images (incl. Alpine) are offered.
- **Install script** (`templates/install-codex.sh`): downloads the latest `codex-<arch>-unknown-linux-musl` release tarball, installs the binary to `/usr/local/bin/codex` (globbing for the triple-named binary inside the archive), and writes `/usr/local/bin/ai-pod-codex-notify` — a small helper that POSTs to the host `/notify_user` endpoint on turn completion (same body/header shape as the OpenCode plugin).
- **Server route** (`server/mod.rs`): vends `/install/codex.sh`.
- **Config injection** (`container.rs`): a new `refresh_codex_config_in_volume` merges ai-pod's keys into the persisted `~/.codex/config.toml` on **every launch** (consistent with how Claude/OpenCode configs are always set up), using **`toml_edit`** so the user's other keys, comments, and formatting survive. The keys ai-pod owns:
  - `[mcp_servers.ai-pod]` — a streamable-HTTP MCP server with per-session `X-Api-Key` / `X-Ai-Pod-Session-Id` headers baked in literally. The url is derived from `rt.server_url()`, so it's correct on **both Podman (`host.containers.internal`) and Docker (`host.docker.internal`)**.
  - `experimental_use_rmcp_client = true` (enables native streamable-HTTP MCP)
  - `approval_policy = "never"` + `sandbox_mode = "danger-full-access"` (the container is the sandbox, mirroring Claude's `bypassPermissions` and OpenCode's YOLO)
  - `notify = ["/usr/local/bin/ai-pod-codex-notify"]`
- **First-init copy**: host `~/.codex/auth.json` and `config.toml` are copied into the volume on first init so the user starts logged in with their model/provider prefs; `~/.codex` is added to the seeded dir list.
- **Tests**: four unit tests for the config merge (empty input, preserves existing keys/comments, runtime gateway in url, stale-session overwrite) + `config.rs` path-helper test, and a `codex` case in `tests/e2e_agents.sh`.
- **README** updates throughout.

## Note on overwrite behavior

`approval_policy`, `sandbox_mode`, `notify`, and `[mcp_servers.ai-pod]` are rewritten on every launch — intentional and consistent with the other agents (the container provides isolation). A user's stricter values for these specific keys are overridden each run; everything else in `config.toml` is preserved. `auth.json` is never touched.

## Verification

- `cargo build` and `cargo test` (188 lib tests) pass locally.
- `sh -n templates/install-codex.sh` passes.
- End-to-end (requires podman/docker, not run in CI here): `./tests/e2e_agents.sh codex alpine` (musl-on-musl) and `./tests/e2e_agents.sh codex ubuntu` (musl-on-glibc).

https://claude.ai/code/session_01SLwmgS2t2q8tW8MfcbGtjQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLwmgS2t2q8tW8MfcbGtjQ)_