### PR TITLE
Make image paste work inside an ai-pod container

### DIFF
--- a/src/server/clipboard.rs
+++ b/src/server/clipboard.rs
@@ -1,0 +1,132 @@
+//! Host-side clipboard reader for the container paste bridge.
+//!
+//! Claude Code, running inside an ai-pod container, reads the clipboard by
+//! shelling out to `xclip`/`wl-paste`. Those tools (and any X11/Wayland socket)
+//! are absent in the container, so paste fails. The container instead forwards
+//! the read to the host's `GET /clipboard/image` endpoint, which calls
+//! [`read_clipboard_png`] here on the host where the real clipboard lives.
+//!
+//! Only image bytes are ever returned — never clipboard text — which keeps the
+//! bridge from leaking arbitrary copied secrets into the container.
+
+/// PNG file signature (the first 8 bytes of every PNG).
+const PNG_MAGIC: &[u8] = b"\x89PNG\r\n\x1a\n";
+
+/// Return `bytes` only if they begin with the PNG magic. Anything else (empty
+/// output, an error string printed to stdout, a truncated read) yields `None`,
+/// so the endpoint never reports non-image data as an image.
+fn valid_png(bytes: Vec<u8>) -> Option<Vec<u8>> {
+    if bytes.starts_with(PNG_MAGIC) {
+        Some(bytes)
+    } else {
+        None
+    }
+}
+
+/// Read the host clipboard and return it as PNG bytes, or `None` when the
+/// clipboard holds no image (or the platform has no supported reader).
+///
+/// Blocking: shells out to platform tools. Callers on the async server run this
+/// inside `spawn_blocking`.
+#[cfg(target_os = "macos")]
+pub fn read_clipboard_png() -> Option<Vec<u8>> {
+    use std::process::Command;
+
+    // Fast path: pngpaste streams PNG bytes straight to stdout when present.
+    if let Ok(out) = Command::new("pngpaste").arg("-").output() {
+        if out.status.success() {
+            if let Some(png) = valid_png(out.stdout) {
+                return Some(png);
+            }
+        }
+    }
+
+    // Fallback: osascript coerces the clipboard to PNG and writes it to a temp
+    // file (AppleScript can't reliably emit raw bytes on stdout). If the
+    // clipboard has no image, the `as «class PNGf»` coercion errors and the
+    // script aborts before writing — leaving us with `None`.
+    let path = std::env::temp_dir().join(format!(
+        "ai-pod-clip-{}-{}.png",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let script = format!(
+        "set thePath to \"{}\"\n\
+         set theData to (the clipboard as «class PNGf»)\n\
+         set theFile to open for access POSIX file thePath with write permission\n\
+         set eof of theFile to 0\n\
+         write theData to theFile\n\
+         close access theFile",
+        path.display()
+    );
+    let status = Command::new("osascript").arg("-e").arg(&script).output();
+    let result = match status {
+        Ok(out) if out.status.success() => std::fs::read(&path).ok().and_then(valid_png),
+        _ => None,
+    };
+    let _ = std::fs::remove_file(&path);
+    result
+}
+
+/// Read the host clipboard and return it as PNG bytes, or `None` when the
+/// clipboard holds no image (or the platform has no supported reader).
+#[cfg(target_os = "linux")]
+pub fn read_clipboard_png() -> Option<Vec<u8>> {
+    use std::process::Command;
+
+    // Wayland first (host OS priority), then X11 as a free fallback.
+    let attempts: [(&str, &[&str]); 2] = [
+        ("wl-paste", &["--type", "image/png"]),
+        (
+            "xclip",
+            &["-selection", "clipboard", "-t", "image/png", "-o"],
+        ),
+    ];
+    for (bin, args) in attempts {
+        if let Ok(out) = Command::new(bin).args(args).output() {
+            if out.status.success() {
+                if let Some(png) = valid_png(out.stdout) {
+                    return Some(png);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Platforms without a supported clipboard reader: paste simply yields nothing.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn read_clipboard_png() -> Option<Vec<u8>> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_png_accepts_real_magic() {
+        let mut bytes = PNG_MAGIC.to_vec();
+        bytes.extend_from_slice(b"...rest of a png...");
+        assert_eq!(valid_png(bytes.clone()), Some(bytes));
+    }
+
+    #[test]
+    fn valid_png_rejects_empty() {
+        assert_eq!(valid_png(Vec::new()), None);
+    }
+
+    #[test]
+    fn valid_png_rejects_text() {
+        assert_eq!(valid_png(b"xclip: error: no image".to_vec()), None);
+    }
+
+    #[test]
+    fn valid_png_rejects_truncated_magic() {
+        // First few bytes of the magic but cut short — not a PNG.
+        assert_eq!(valid_png(b"\x89PNG".to_vec()), None);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,4 @@
+pub mod clipboard;
 pub mod commands;
 pub mod lifecycle;
 pub mod mcp;
@@ -58,6 +59,7 @@ async fn version_handler() -> Json<serde_json::Value> {
 
 const INSTALL_CLAUDE_SH: &str = include_str!("../../templates/install-claude.sh");
 const INSTALL_OPENCODE_SH: &str = include_str!("../../templates/install-opencode.sh");
+const INSTALL_CLIPBOARD_SH: &str = include_str!("../../templates/install-clipboard.sh");
 
 /// Stub returned when an outdated `ai-pod.Dockerfile` still tries to fetch
 /// `/host-tools`. The bundled `host-tools` binary was removed in 0.11.0 in
@@ -115,6 +117,7 @@ async fn install_script_handler(AxumPath(name): AxumPath<String>) -> Response {
     let body = match name.as_str() {
         "claude.sh" => INSTALL_CLAUDE_SH,
         "opencode.sh" => INSTALL_OPENCODE_SH,
+        "clipboard.sh" => INSTALL_CLIPBOARD_SH,
         _ => {
             return (StatusCode::NOT_FOUND, "Unknown install script").into_response();
         }
@@ -171,6 +174,7 @@ pub fn build_app(state: AppState) -> Router {
         .route("/commands/stop", post(rest::stop_command_handler))
         .route("/commands/status", post(rest::command_status_handler))
         .route("/commands/list", post(rest::list_commands_handler))
+        .route("/clipboard/image", get(rest::clipboard_image_handler))
         .route("/mcp", post(mcp::mcp_handler))
         .layer(GovernorLayer::new(governor_conf))
         .layer(middleware::from_fn(add_retry_after_header));

--- a/src/server/rest.rs
+++ b/src/server/rest.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json,
-    extract::State,
-    http::{HeaderMap, StatusCode},
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode, header},
     response::IntoResponse,
 };
 use serde::{Deserialize, Serialize};
@@ -76,6 +76,11 @@ pub struct ListAllowedCommandsRequest {
 #[derive(Serialize)]
 pub struct ListAllowedCommandsResponse {
     pub commands: Vec<String>,
+}
+
+#[derive(Deserialize)]
+pub struct ClipboardQuery {
+    pub project_id: String,
 }
 
 fn extract_api_key(headers: &HeaderMap) -> &str {
@@ -242,4 +247,29 @@ pub async fn list_allowed_commands_handler(
 
     let cmds = commands::get_allowed_commands(&state, &workspace);
     Json(ListAllowedCommandsResponse { commands: cmds }).into_response()
+}
+
+/// Read the host clipboard and return it as a PNG image. Backs the container's
+/// fake `xclip`/`wl-paste` shims so native Ctrl+V paste works inside a pod.
+///
+/// `200 image/png` when the clipboard holds an image, `204 No Content` when it
+/// is empty / non-image, `401`/`404` on auth failure. Returns image bytes only,
+/// never clipboard text.
+pub async fn clipboard_image_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(q): Query<ClipboardQuery>,
+) -> impl IntoResponse {
+    let provided_key = extract_api_key(&headers).to_string();
+    if let Err((status, msg)) = authenticate(&state, &q.project_id, &provided_key).await {
+        return (status, msg.to_string()).into_response();
+    }
+
+    match tokio::task::spawn_blocking(super::clipboard::read_clipboard_png).await {
+        Ok(Some(bytes)) => {
+            (StatusCode::OK, [(header::CONTENT_TYPE, "image/png")], bytes).into_response()
+        }
+        Ok(None) => StatusCode::NO_CONTENT.into_response(),
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
 }

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -6,6 +6,12 @@ ARG HOST_GATEWAY
 ARG AI_POD_VERSION
 RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/{{AGENT}}.sh" | bash
 
+# Clipboard bridge: fake xclip/wl-paste shims so Ctrl+V image paste works.
+# Referencing AI_POD_VERSION busts this layer's cache on a version bump so the
+# shims refresh on rebuild.
+RUN echo "ai-pod ${AI_POD_VERSION}" && \
+    curl -fsSL "http://${HOST_GATEWAY}:7822/install/clipboard.sh" | bash
+
 WORKDIR /app
 
 {{CREATE_USER}}

--- a/templates/install-clipboard.sh
+++ b/templates/install-clipboard.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Installed in-container by the ai-pod Dockerfile via:
+#   curl http://${HOST_GATEWAY}:7822/install/clipboard.sh | bash
+#
+# Writes fake `xclip` and `wl-paste` shims that forward clipboard-image reads to
+# the host's GET /clipboard/image endpoint. This lets Claude Code's native
+# Ctrl+V paste work inside the container, where no real clipboard tools or
+# display server exist. The shims read the runtime env vars (AI_POD_SERVER_URL,
+# AI_POD_API_KEY, AI_POD_PROJECT_ID) injected into every container, and `curl`
+# (present in every base image). /usr/local/bin is ahead of /usr/bin in PATH and
+# no real xclip/wl-paste is installed, so there is no conflict.
+set -e
+
+# xclip shim. Claude detects available types with `-t TARGETS -o` (greps stdout
+# for image/<fmt>) then extracts with `-t image/png -o`. We answer both: print
+# the single line `image/png` for TARGETS (only when the host clipboard has an
+# image), and stream the PNG bytes otherwise. `curl -fsS` exits non-zero on the
+# endpoint's 204 (empty clipboard), so TARGETS prints nothing and Claude
+# correctly reports "no image" with no hang.
+cat > /usr/local/bin/xclip <<'SHIM'
+#!/bin/sh
+url="${AI_POD_SERVER_URL}/clipboard/image?project_id=${AI_POD_PROJECT_ID}"
+fetch() { curl -fsS -H "X-Api-Key: ${AI_POD_API_KEY}" "$url"; }
+case " $* " in
+  *" TARGETS "*) if fetch >/dev/null 2>&1; then echo image/png; fi; exit 0 ;;
+esac
+fetch; exit 0
+SHIM
+chmod 0755 /usr/local/bin/xclip
+echo "Installed xclip shim at /usr/local/bin/xclip"
+
+# wl-paste shim. Same contract, but Wayland lists types with `-l` /
+# `--list-types` and extracts with `--type image/png`.
+cat > /usr/local/bin/wl-paste <<'SHIM'
+#!/bin/sh
+url="${AI_POD_SERVER_URL}/clipboard/image?project_id=${AI_POD_PROJECT_ID}"
+fetch() { curl -fsS -H "X-Api-Key: ${AI_POD_API_KEY}" "$url"; }
+case " $* " in
+  *" -l "*|*" --list-types "*) if fetch >/dev/null 2>&1; then echo image/png; fi; exit 0 ;;
+esac
+fetch; exit 0
+SHIM
+chmod 0755 /usr/local/bin/wl-paste
+echo "Installed wl-paste shim at /usr/local/bin/wl-paste"


### PR DESCRIPTION
## Problem

When Claude Code runs **inside** an ai-pod container, pressing **Ctrl+V** to paste an image fails with "No image found in clipboard". On Linux, Claude Code reads the clipboard by shelling out to `xclip` (then `wl-paste`). Inside the container those tools aren't installed and there's no X11/Wayland socket, so the read fails silently.

## Solution

A pull-based **host-clipboard bridge** so native Ctrl+V "just works" — no changes to Claude Code itself.

**Part A — Host endpoint `GET /clipboard/image`** (`src/server/clipboard.rs`, `rest.rs`, `mod.rs`)
- `read_clipboard_png()` reads the host clipboard and returns PNG bytes: macOS via `pngpaste`/`osascript`, Linux via `wl-paste`/`xclip`.
- Reuses the existing per-project API-key auth (`extract_api_key` + `authenticate`) and runs the blocking read in `spawn_blocking`.
- `200 image/png` when the clipboard holds an image, `204 No Content` when empty/non-image, `401`/`404` on auth failure.
- Validates the PNG magic so an error string on stdout is never mistaken for an image. **Image bytes only — never clipboard text** (a natural secret-leak limit).

**Part B — Container shims** (`templates/install-clipboard.sh`, `Dockerfile`)
- Fake `xclip`/`wl-paste` shims in `/usr/local/bin` forward clipboard-image reads to the host endpoint using the runtime env vars (`AI_POD_SERVER_URL`, `AI_POD_API_KEY`, `AI_POD_PROJECT_ID`) already injected into every container, via `curl` (present in every base image).
- Served via `/install/clipboard.sh`; installed by the Dockerfile template. The install layer references `AI_POD_VERSION` so it refreshes on version bumps.

## Flow

```
Claude TUI (in container)              host (ai-pod server)
  Ctrl+V
   └─ xclip -t TARGETS -o   ──►  /usr/local/bin/xclip shim
   └─ xclip -t image/png -o ──►  curl → GET /clipboard/image
                                   ├─ authenticate(state, pid, key)
                                   └─ spawn_blocking → read_clipboard_png()
                                   200 image/png | 204 empty | 401/404
```

## Migration

Rebuilds aren't automatic. **New pods** get the feature from the updated template. **Existing pods** need `ai-pod --rebuild` (`--no-cache` to be sure the install layer refreshes). Users who already have an `ai-pod.Dockerfile` must add the clipboard `RUN` line themselves, or delete + re-init.

## Testing

- `cargo build` ✅ / `cargo test` ✅ (202 lib + 16 e2e passing, incl. new `valid_png` unit tests).
- Endpoint, shim, and end-to-end manual verification steps are documented in the plan. The platform clipboard reads (macOS/Linux display server) can only be exercised on a real host, not in CI.

https://claude.ai/code/session_016Ef6Y6xiJJJbwAsb7ekLxE

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ef6Y6xiJJJbwAsb7ekLxE)_