### PR TITLE
Add --ssh flag to forward host SSH agent into the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ ai-pod --workdir /path/to/project
 | `--no-cache` | Build the image without the Docker/Podman layer cache |
 | `--no-credential-check` | Skip scanning the workspace for credential files |
 | `--dry-run` | Print podman/docker commands instead of executing them |
+| `--ssh` | Forward the host's SSH agent into the container (enables `git push` over SSH) |
+
+### Forwarding the SSH agent (`--ssh`)
+
+Pass `--ssh` to bridge your host's running SSH agent into the container so
+`git push`, `git clone`, and other SSH operations authenticate with your host
+keys — without exposing the private key files themselves (only the live agent
+socket is shared, so the credential hiding of `~/.ssh` is unaffected). Your host
+git identity is already seeded into the container, and `known_hosts` accumulates
+in the persistent home volume, so the first interactive push prompts to trust a
+host once and subsequent pushes are silent.
+
+Requirements and caveats:
+
+- A running agent with a loaded key on the host (`ssh-add -l` should list one).
+- **Docker Desktop on macOS** is bridged automatically via Docker's built-in
+  agent socket — no extra setup.
+- **Rootless podman** runs the container in a user namespace, so ai-pod adds
+  `--userns=keep-id` and uses a separate home volume (suffixed `-kid`) so the
+  in-container user can read the socket. The first `--ssh` launch re-seeds this
+  volume.
+- **Docker / rootful podman on Linux** assume your host user is UID 1000 (the
+  container's `ai-pod` user); a different UID may hit socket permission errors.
+- **podman-machine on macOS** is best-effort — it only works if `$SSH_AUTH_SOCK`
+  is reachable inside the podman VM.
+- On SELinux-enforcing hosts the socket mount may need additional configuration.
 
 ### Subcommands
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,6 +45,12 @@ pub struct Cli {
     /// Container runtime to use (overrides AI_POD_RUNTIME and autodetect)
     #[arg(long, value_enum)]
     pub runtime: Option<crate::runtime::RuntimeKind>,
+
+    /// Forward the host's SSH agent into the container (enables `git push` over SSH).
+    /// Requires a running agent (`ssh-add -l`); on Docker Desktop for macOS the
+    /// host agent is bridged automatically.
+    #[arg(long)]
+    pub ssh: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/container.rs
+++ b/src/container.rs
@@ -17,6 +17,54 @@ use crate::workspace::{
 /// runtime does not need to probe the image.
 const CONTAINER_HOME: &str = "/home/ai-pod";
 
+/// `--userns=keep-id` args, used when rootless podman forwards the host SSH
+/// agent: the host UID is mapped 1:1 so the unprivileged in-container `ai-pod`
+/// user can read the bind-mounted agent socket and the home volume seeded under
+/// the same mapping. Empty otherwise.
+fn userns_args(keep_id: bool) -> &'static [&'static str] {
+    if keep_id {
+        &["--userns", "keep-id"]
+    } else {
+        &[]
+    }
+}
+
+/// Home volume name, suffixed with `-kid` when seeded under keep-id. A keep-id
+/// volume's on-disk ownership is interpreted through a different userns mapping
+/// than a default one, so the two must never share a name.
+fn home_volume_name(workspace: &Path, keep_id: bool) -> String {
+    let base = gen_volume_name(workspace);
+    if keep_id {
+        format!("{}-kid", base)
+    } else {
+        base
+    }
+}
+
+/// Mask volume name, suffixed the same way as the home volume under keep-id.
+fn mask_vol_name(workspace: &Path, dir: &str, keep_id: bool) -> String {
+    let base = mask_volume_name(workspace, dir);
+    if keep_id {
+        format!("{}-kid", base)
+    } else {
+        base
+    }
+}
+
+/// Bind-mount + env args that forward the host's SSH agent into the container,
+/// so `git push` and other SSH operations authenticate with the host's keys.
+/// Errors (before any container is started) if no agent is available.
+fn ssh_agent_run_args(rt: &ContainerRuntime) -> Result<Vec<String>> {
+    let src = rt.ssh_agent_source()?;
+    let dst = crate::runtime::SSH_AGENT_CONTAINER_PATH;
+    Ok(vec![
+        "-v".to_string(),
+        format!("{}:{}", src, dst),
+        "-e".to_string(),
+        format!("SSH_AUTH_SOCK={}", dst),
+    ])
+}
+
 pub fn containers_for_prefix(
     rt: &ContainerRuntime,
     prefix: &str,
@@ -58,25 +106,28 @@ pub fn volume_exists(rt: &ContainerRuntime, name: &str) -> Result<bool> {
 
 /// Create a fresh mask volume and chown its root to the container's `ai-pod` user
 /// so the unprivileged in-container user can write under /app/<dir>.
-fn seed_mask_volume(rt: &ContainerRuntime, image: &str, vol: &str, dir: &str) -> Result<()> {
+fn seed_mask_volume(
+    rt: &ContainerRuntime,
+    image: &str,
+    vol: &str,
+    dir: &str,
+    keep_id: bool,
+) -> Result<()> {
     let mount_path = format!("/app/{}", dir);
-    let status = rt
-        .command()
-        .args([
-            "run",
-            "--rm",
-            "--user",
-            "0",
-            "-v",
-            &format!("{}:{}:Z", vol, mount_path),
-            "--entrypoint",
-            "chown",
-            image,
-            "ai-pod:ai-pod",
-            &mount_path,
-        ])
-        .status()
-        .context("Failed to seed mask volume")?;
+    let mut cmd = rt.command();
+    cmd.arg("run").args(userns_args(keep_id)).args([
+        "--rm",
+        "--user",
+        "0",
+        "-v",
+        &format!("{}:{}:Z", vol, mount_path),
+        "--entrypoint",
+        "chown",
+        image,
+        "ai-pod:ai-pod",
+        &mount_path,
+    ]);
+    let status = cmd.status().context("Failed to seed mask volume")?;
     if !status.success() {
         anyhow::bail!("Failed to chown mask volume {}", vol);
     }
@@ -90,8 +141,9 @@ fn ensure_mask_volume(
     workspace: &Path,
     image: &str,
     dir: &str,
+    keep_id: bool,
 ) -> Result<String> {
-    let vol = mask_volume_name(workspace, dir);
+    let vol = mask_vol_name(workspace, dir, keep_id);
     if !volume_exists(rt, &vol)? {
         eprintln!("{} {}", "Creating mask volume:".blue().bold(), vol);
         let status = rt
@@ -102,7 +154,7 @@ fn ensure_mask_volume(
         if !status.success() {
             anyhow::bail!("Failed to create mask volume {}", vol);
         }
-        seed_mask_volume(rt, image, &vol, dir)?;
+        seed_mask_volume(rt, image, &vol, dir, keep_id)?;
     }
     Ok(vol)
 }
@@ -116,10 +168,11 @@ fn mask_mount_args(
     workspace: &Path,
     image: &str,
     masks: &[String],
+    keep_id: bool,
 ) -> Result<Vec<String>> {
     let mut out = Vec::with_capacity(masks.len() * 2);
     for dir in masks {
-        let vol = ensure_mask_volume(rt, workspace, image, dir)?;
+        let vol = ensure_mask_volume(rt, workspace, image, dir, keep_id)?;
         out.push("-v".to_string());
         out.push(format!("{}:/app/{}:Z", vol, dir));
     }
@@ -202,25 +255,31 @@ pub(crate) fn build_mount_args(home_dir: &Path, mounts: &[MountSpec]) -> Result<
 /// Best-effort removal of a single mask volume. Prints a message on success and
 /// a warning if the volume is in use (e.g. another container still mounts it).
 pub fn remove_mask_volume(rt: &ContainerRuntime, workspace: &Path, dir: &str) -> Result<()> {
-    let vol = mask_volume_name(workspace, dir);
-    if !volume_exists(rt, &vol)? {
-        return Ok(());
-    }
-    let output = rt
-        .command()
-        .args(["volume", "rm", &vol])
-        .output()
-        .context("Failed to remove mask volume")?;
-    if output.status.success() {
-        eprintln!("{} {}", "Removed volume:".red().bold(), vol);
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        eprintln!(
-            "{} could not remove {} ({})",
-            "Warning:".yellow().bold(),
-            vol,
-            stderr.trim()
-        );
+    // Remove both the default-mapping volume and the keep-id (`--ssh` on rootless
+    // podman) variant, since either may have been created for this dir.
+    for vol in [
+        mask_vol_name(workspace, dir, false),
+        mask_vol_name(workspace, dir, true),
+    ] {
+        if !volume_exists(rt, &vol)? {
+            continue;
+        }
+        let output = rt
+            .command()
+            .args(["volume", "rm", &vol])
+            .output()
+            .context("Failed to remove mask volume")?;
+        if output.status.success() {
+            eprintln!("{} {}", "Removed volume:".red().bold(), vol);
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!(
+                "{} could not remove {} ({})",
+                "Warning:".yellow().bold(),
+                vol,
+                stderr.trim()
+            );
+        }
     }
     Ok(())
 }
@@ -383,19 +442,19 @@ fn seed_home_volume(
     container_name: &str,
     image: &str,
     copy_claude_json: bool,
+    keep_id: bool,
 ) -> Result<()> {
     let init_container = format!("{}-init", container_name);
-    let status = rt
-        .command()
-        .args([
-            "create",
-            "--name",
-            &init_container,
-            "-v",
-            &format!("{}:{}", volume_name, CONTAINER_HOME),
-            image,
-            "true",
-        ])
+    let mut create_cmd = rt.command();
+    create_cmd.arg("create").args(userns_args(keep_id)).args([
+        "--name",
+        &init_container,
+        "-v",
+        &format!("{}:{}", volume_name, CONTAINER_HOME),
+        image,
+        "true",
+    ]);
+    let status = create_cmd
         .status()
         .context("Failed to create init container")?;
     if !status.success() {
@@ -416,21 +475,19 @@ fn seed_home_volume(
         }
     }
 
-    let _ = rt
-        .command()
-        .args([
-            "run",
-            "--rm",
-            "-v",
-            &format!("{}:{}:z", volume_name, CONTAINER_HOME),
-            image,
-            "mkdir",
-            "-p",
-            &format!("{}/.claude", CONTAINER_HOME),
-            &format!("{}/.config", CONTAINER_HOME),
-            &format!("{}/.config/opencode/plugins", CONTAINER_HOME),
-        ])
-        .status();
+    let mut mkdir_cmd = rt.command();
+    mkdir_cmd.arg("run").args(userns_args(keep_id)).args([
+        "--rm",
+        "-v",
+        &format!("{}:{}:z", volume_name, CONTAINER_HOME),
+        image,
+        "mkdir",
+        "-p",
+        &format!("{}/.claude", CONTAINER_HOME),
+        &format!("{}/.config", CONTAINER_HOME),
+        &format!("{}/.config/opencode/plugins", CONTAINER_HOME),
+    ]);
+    let _ = mkdir_cmd.status();
 
     generate_runtime_settings(config)?;
 
@@ -439,7 +496,10 @@ fn seed_home_volume(
         .args([
             "cp",
             &config.runtime_settings.to_string_lossy(),
-            &format!("{}:{}/.claude/settings.json", init_container, CONTAINER_HOME),
+            &format!(
+                "{}:{}/.claude/settings.json",
+                init_container, CONTAINER_HOME
+            ),
         ])
         .status();
 
@@ -490,19 +550,19 @@ fn refresh_claude_mcp_in_volume(
     server_url: &str,
     api_key: &str,
     session_id: &str,
+    keep_id: bool,
 ) -> Result<()> {
     let init_container = format!("{}-mcp", container_name);
-    let status = rt
-        .command()
-        .args([
-            "create",
-            "--name",
-            &init_container,
-            "-v",
-            &format!("{}:{}", volume_name, CONTAINER_HOME),
-            image,
-            "true",
-        ])
+    let mut create_cmd = rt.command();
+    create_cmd.arg("create").args(userns_args(keep_id)).args([
+        "--name",
+        &init_container,
+        "-v",
+        &format!("{}:{}", volume_name, CONTAINER_HOME),
+        image,
+        "true",
+    ]);
+    let status = create_cmd
         .status()
         .context("Failed to create mcp-refresh container")?;
     if !status.success() {
@@ -565,6 +625,7 @@ fn init_home_volume(
     image: &str,
     project_id: &str,
     api_key: &str,
+    keep_id: bool,
 ) -> Result<()> {
     eprintln!(
         "{} {}",
@@ -581,7 +642,15 @@ fn init_home_volume(
         anyhow::bail!("Failed to create volume {}", volume_name);
     }
 
-    seed_home_volume(rt, config, volume_name, container_name, image, true)?;
+    seed_home_volume(
+        rt,
+        config,
+        volume_name,
+        container_name,
+        image,
+        true,
+        keep_id,
+    )?;
 
     let _ = (project_id, api_key); // used via env vars at runtime
 
@@ -600,6 +669,7 @@ fn reseed_home_volume(
     image: &str,
     project_id: &str,
     api_key: &str,
+    keep_id: bool,
 ) -> Result<()> {
     eprintln!(
         "{} {}",
@@ -607,7 +677,15 @@ fn reseed_home_volume(
         volume_name
     );
 
-    seed_home_volume(rt, config, volume_name, container_name, image, false)?;
+    seed_home_volume(
+        rt,
+        config,
+        volume_name,
+        container_name,
+        image,
+        false,
+        keep_id,
+    )?;
 
     let _ = (project_id, api_key); // used via env vars at runtime
 
@@ -624,9 +702,21 @@ pub fn launch_container(
     image: &str,
     project_id: &str,
     api_key: &str,
+    forward_ssh: bool,
 ) -> Result<()> {
+    // Rootless podman needs keep-id (and a dedicated home volume) so the
+    // in-container user can read the forwarded agent socket.
+    let keep_id = forward_ssh && rt.ssh_needs_keep_id();
+    // Resolve the agent socket up front so we fail before touching any volume
+    // or container if no agent is available.
+    let ssh_args = if forward_ssh {
+        ssh_agent_run_args(rt)?
+    } else {
+        Vec::new()
+    };
+
     let prefix = container_prefix(workspace);
-    let volume_name = gen_volume_name(workspace);
+    let volume_name = home_volume_name(workspace, keep_id);
     let workspace_str = workspace.to_string_lossy();
 
     // On rebuild: stop all existing containers for this workspace and reseed the volume
@@ -648,6 +738,7 @@ pub fn launch_container(
                 image,
                 project_id,
                 api_key,
+                keep_id,
             )?;
         }
     }
@@ -662,6 +753,7 @@ pub fn launch_container(
             image,
             project_id,
             api_key,
+            keep_id,
         )?;
     }
 
@@ -682,6 +774,7 @@ pub fn launch_container(
         &rt.server_url(),
         api_key,
         &session_id,
+        keep_id,
     )?;
 
     let add_host = rt.add_host_arg();
@@ -693,7 +786,13 @@ pub fn launch_container(
     );
 
     let project_state = load_project_state(config, workspace);
-    let mask_args = mask_mount_args(rt, workspace, image, &project_state.masked_directories)?;
+    let mask_args = mask_mount_args(
+        rt,
+        workspace,
+        image,
+        &project_state.masked_directories,
+        keep_id,
+    )?;
     let global = GlobalConfig::load(config);
     let user_mount_args = build_mount_args(&config.home_dir, &global.mounts)?;
 
@@ -707,6 +806,7 @@ pub fn launch_container(
 
     let mut run_cmd = rt.command();
     run_cmd.args(["run", "--rm", "-it"]);
+    run_cmd.args(userns_args(keep_id));
     run_cmd.args([
         "--name",
         &container_name,
@@ -723,6 +823,9 @@ pub fn launch_container(
         run_cmd.arg(arg);
     }
     for arg in &mask_args {
+        run_cmd.arg(arg);
+    }
+    for arg in &ssh_args {
         run_cmd.arg(arg);
     }
     run_cmd.args([
@@ -768,10 +871,19 @@ pub fn run_in_container(
     command: &str,
     args: &[String],
     interactive: bool,
+    forward_ssh: bool,
 ) -> Result<()> {
+    let keep_id = forward_ssh && rt.ssh_needs_keep_id();
+    // Resolve the agent socket up front so we fail before starting anything.
+    let ssh_args = if forward_ssh {
+        ssh_agent_run_args(rt)?
+    } else {
+        Vec::new()
+    };
+
     let session_id = new_session_id();
     let container_name = container_name_for(workspace, &session_id);
-    let volume_name = gen_volume_name(workspace);
+    let volume_name = home_volume_name(workspace, keep_id);
     let workspace_str = workspace.to_string_lossy();
 
     // Record the runtime for this session before the container starts, so the
@@ -788,6 +900,7 @@ pub fn run_in_container(
             image,
             project_id,
             api_key,
+            keep_id,
         )?;
     }
 
@@ -800,6 +913,7 @@ pub fn run_in_container(
         &rt.server_url(),
         api_key,
         &session_id,
+        keep_id,
     )?;
 
     eprintln!(
@@ -810,7 +924,13 @@ pub fn run_in_container(
     );
 
     let project_state = load_project_state(config, workspace);
-    let mask_args = mask_mount_args(rt, workspace, image, &project_state.masked_directories)?;
+    let mask_args = mask_mount_args(
+        rt,
+        workspace,
+        image,
+        &project_state.masked_directories,
+        keep_id,
+    )?;
     let global = GlobalConfig::load(config);
     let user_mount_args = build_mount_args(&config.home_dir, &global.mounts)?;
 
@@ -823,11 +943,8 @@ pub fn run_in_container(
     // ACP), `-t` would allocate a pseudo-TTY that mangles the JSON-RPC
     // byte stream the agent emits. Keep `-i` so stdin stays attached.
     let stdio_flag = if interactive { "-it" } else { "-i" };
-    let mut run_args: Vec<String> = vec![
-        "run".into(),
-        "--rm".into(),
-        stdio_flag.into(),
-    ];
+    let mut run_args: Vec<String> = vec!["run".into(), "--rm".into(), stdio_flag.into()];
+    run_args.extend(userns_args(keep_id).iter().map(|s| s.to_string()));
     run_args.extend_from_slice(&[
         "--label".into(),
         "managed-by=ai-pod".into(),
@@ -840,6 +957,7 @@ pub fn run_in_container(
     ]);
     run_args.extend(user_mount_args);
     run_args.extend(mask_args);
+    run_args.extend(ssh_args);
     run_args.extend_from_slice(&[
         rt.add_host_arg(),
         "-e".into(),
@@ -972,7 +1090,6 @@ pub fn clean_container(
     workspace: &Path,
 ) -> Result<()> {
     let prefix = container_prefix(workspace);
-    let volume_name = gen_volume_name(workspace);
 
     let containers = containers_for_prefix(rt, &prefix, false)?;
 
@@ -986,16 +1103,22 @@ pub fn clean_container(
         println!("{}", "Containers removed.".green());
     }
 
-    // Remove named home volume
-    if volume_exists(rt, &volume_name)? {
-        println!("{} {}", "Removing volume:".red().bold(), volume_name);
-        let status = rt
-            .command()
-            .args(["volume", "rm", &volume_name])
-            .status()
-            .context("Failed to remove volume")?;
-        if status.success() {
-            println!("{}", "Volume removed.".green());
+    // Remove named home volume(s): both the default-mapping volume and the
+    // keep-id (`--ssh` on rootless podman) variant, if present.
+    for volume_name in [
+        home_volume_name(workspace, false),
+        home_volume_name(workspace, true),
+    ] {
+        if volume_exists(rt, &volume_name)? {
+            println!("{} {}", "Removing volume:".red().bold(), volume_name);
+            let status = rt
+                .command()
+                .args(["volume", "rm", &volume_name])
+                .status()
+                .context("Failed to remove volume")?;
+            if status.success() {
+                println!("{}", "Volume removed.".green());
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,6 +284,7 @@ async fn launch_flow(cli: &Cli, rt: &ContainerRuntime) -> Result<()> {
         &image,
         &project_id,
         &state.api_key,
+        cli.ssh,
     )?;
 
     Ok(())
@@ -548,6 +549,7 @@ async fn main() -> Result<()> {
                 command,
                 args,
                 interactive,
+                cli.ssh,
             )?;
         }
         Some(Command::Commands { action }) => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -48,6 +48,34 @@ impl FromStr for RuntimeKind {
     }
 }
 
+/// Path the forwarded host SSH agent socket is mounted to inside the container.
+/// `SSH_AUTH_SOCK` is set to this so git/ssh in the pod find the host agent.
+pub const SSH_AGENT_CONTAINER_PATH: &str = "/run/ssh-agent.sock";
+
+/// Docker Desktop on macOS bridges the host's SSH agent to this in-VM socket.
+/// Mounting the raw `$SSH_AUTH_SOCK` does not work there because the runtime
+/// lives in a VM that cannot see the host's socket directly.
+const DOCKER_DESKTOP_SSH_SOCK: &str = "/run/host-services/ssh-auth.sock";
+
+/// Resolve the host-side SSH agent socket to bind into the container. Pure so it
+/// can be unit-tested across platform/runtime combinations.
+fn resolve_ssh_agent_source(
+    kind: RuntimeKind,
+    is_macos: bool,
+    env_sock: Option<String>,
+) -> Result<String> {
+    if is_macos && kind == RuntimeKind::Docker {
+        return Ok(DOCKER_DESKTOP_SSH_SOCK.to_string());
+    }
+    match env_sock.filter(|s| !s.is_empty()) {
+        Some(sock) => Ok(sock),
+        None => anyhow::bail!(
+            "No SSH agent found: $SSH_AUTH_SOCK is not set. Start one with \
+             `eval \"$(ssh-agent)\"` and `ssh-add`, or drop the --ssh flag."
+        ),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ContainerRuntime {
     pub kind: RuntimeKind,
@@ -134,6 +162,41 @@ impl ContainerRuntime {
     /// The server URL using the correct gateway hostname.
     pub fn server_url(&self) -> String {
         format!("http://{}:7822", self.host_gateway())
+    }
+
+    /// Whether this runtime maps the host user into a separate user namespace
+    /// (rootless podman). In that mode an unprivileged in-container user cannot
+    /// read a bind-mounted host socket unless we run with `--userns=keep-id`.
+    /// Docker is treated as non-rootless. Under `dry_run` we assume rootless
+    /// podman so the previewed command reflects the keep-id path.
+    pub fn is_rootless(&self) -> bool {
+        if self.kind == RuntimeKind::Docker {
+            return false;
+        }
+        if self.dry_run {
+            return true;
+        }
+        Command::new(self.cmd())
+            .args(["info", "--format", "{{.Host.Security.Rootless}}"])
+            .output()
+            .ok()
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "true")
+            .unwrap_or(false)
+    }
+
+    /// Whether forwarding the host SSH agent needs `--userns=keep-id` (rootless
+    /// podman) so the in-container `ai-pod` user can read the agent socket.
+    pub fn ssh_needs_keep_id(&self) -> bool {
+        self.kind == RuntimeKind::Podman && self.is_rootless()
+    }
+
+    /// The host-side SSH agent socket to bind into the container.
+    pub fn ssh_agent_source(&self) -> Result<String> {
+        resolve_ssh_agent_source(
+            self.kind,
+            cfg!(target_os = "macos"),
+            std::env::var("SSH_AUTH_SOCK").ok(),
+        )
     }
 
     /// Display name for the runtime (e.g. in generated docs).
@@ -255,6 +318,60 @@ mod tests {
             let pv = kind.to_possible_value().unwrap();
             assert_eq!(pv.get_name(), kind.as_str());
         }
+    }
+
+    #[test]
+    fn ssh_source_uses_docker_desktop_socket_on_macos() {
+        let src =
+            resolve_ssh_agent_source(RuntimeKind::Docker, true, Some("/tmp/agent.sock".into()))
+                .unwrap();
+        assert_eq!(src, "/run/host-services/ssh-auth.sock");
+    }
+
+    #[test]
+    fn ssh_source_uses_env_sock_for_podman_on_macos() {
+        // podman-machine on macOS still relies on $SSH_AUTH_SOCK being reachable.
+        let src =
+            resolve_ssh_agent_source(RuntimeKind::Podman, true, Some("/tmp/agent.sock".into()))
+                .unwrap();
+        assert_eq!(src, "/tmp/agent.sock");
+    }
+
+    #[test]
+    fn ssh_source_uses_env_sock_on_linux() {
+        for kind in [RuntimeKind::Podman, RuntimeKind::Docker] {
+            let src =
+                resolve_ssh_agent_source(kind, false, Some("/run/user/1000/ssh".into())).unwrap();
+            assert_eq!(src, "/run/user/1000/ssh");
+        }
+    }
+
+    #[test]
+    fn ssh_source_errors_when_no_agent() {
+        let err = resolve_ssh_agent_source(RuntimeKind::Podman, false, None).unwrap_err();
+        assert!(err.to_string().contains("SSH_AUTH_SOCK"));
+        // Empty string is treated the same as unset.
+        assert!(resolve_ssh_agent_source(RuntimeKind::Docker, false, Some(String::new())).is_err());
+    }
+
+    #[test]
+    fn docker_is_never_rootless() {
+        let rt = ContainerRuntime {
+            kind: RuntimeKind::Docker,
+            dry_run: true,
+        };
+        assert!(!rt.is_rootless());
+        assert!(!rt.ssh_needs_keep_id());
+    }
+
+    #[test]
+    fn dry_run_podman_assumes_rootless_keep_id() {
+        let rt = ContainerRuntime {
+            kind: RuntimeKind::Podman,
+            dry_run: true,
+        };
+        assert!(rt.is_rootless());
+        assert!(rt.ssh_needs_keep_id());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds a global `--ssh` flag that bridges the host's running SSH agent into the container, so `git push` / `git clone` and other SSH operations inside the pod authenticate with the host's keys — without exposing the private key files themselves (only the live agent socket is shared, so the credential-hiding of `~/.ssh` is unaffected).

The host git identity is already seeded into the home volume, and `known_hosts` persists in that volume, so the first interactive push prompts to trust a host once and subsequent pushes are silent.

## How

- New `--ssh` flag on the `Cli` struct, wired through both `launch_container` and `run_in_container`.
- **Socket resolution** (`runtime.rs`): Docker Desktop on macOS uses the built-in `/run/host-services/ssh-auth.sock` bridge; everything else uses `$SSH_AUTH_SOCK`. Resolved up front so we fail with a clear message *before* starting any container if no agent is running.
- Mounts the socket at `/run/ssh-agent.sock` and sets `SSH_AUTH_SOCK` in the container.
- **Rootless podman**: the in-container `ai-pod` user can't read a bind-mounted host socket under the default userns mapping, so we add `--userns=keep-id` and use a dedicated home volume (`-kid` suffix) that's seeded under the same mapping. `clean` removes both volume variants.
- Docker / rootful podman need no userns change.
- README documents the flag and per-platform caveats.

## Platform coverage

| Setup | Behaviour |
|---|---|
| Docker / rootful podman (Linux) | Mount + env (assumes host UID == container UID 1000) |
| Docker Desktop (macOS) | Auto-bridged via Docker's agent socket |
| Rootless podman (Linux) | `--userns=keep-id` + dedicated `-kid` home volume |
| podman-machine (macOS) | Best-effort (needs `$SSH_AUTH_SOCK` reachable in the VM) |

## Testing

- New unit tests for socket resolution across platform/runtime combos and rootless/keep-id detection.
- `cargo test --lib` (204) and `cargo test --test e2e` (16) pass.
- Verified via `--dry-run`:
  - podman → emits `--userns keep-id`, `-kid` volume name, socket mount + env
  - docker → emits socket mount + env, no keep-id / no `-kid`
  - no agent → bails with the clear "No SSH agent found" error
  - without `--ssh` → output unchanged

https://claude.ai/code/session_016NQpxV7yXun7YHmXM7nxWM

---
_Generated by [Claude Code](https://claude.ai/code/session_016NQpxV7yXun7YHmXM7nxWM)_