### PR TITLE
feat: warn about rootless Podman UID-namespace mismatch at launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-pod"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/src/container.rs
+++ b/src/container.rs
@@ -629,6 +629,8 @@ pub fn launch_container(
     let volume_name = gen_volume_name(workspace);
     let workspace_str = workspace.to_string_lossy();
 
+    rt.warn_if_rootless_userns_mismatch();
+
     // On rebuild: stop all existing containers for this workspace and reseed the volume
     if rebuild {
         for name in containers_for_prefix(rt, &prefix, false)? {
@@ -773,6 +775,8 @@ pub fn run_in_container(
     let container_name = container_name_for(workspace, &session_id);
     let volume_name = gen_volume_name(workspace);
     let workspace_str = workspace.to_string_lossy();
+
+    rt.warn_if_rootless_userns_mismatch();
 
     // Record the runtime for this session before the container starts, so the
     // shared server runs service containers on the same runtime.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use clap::ValueEnum;
+use colored::Colorize;
 use serde::{Deserialize, Serialize};
+use std::env;
 use std::process::Command;
 use std::str::FromStr;
 
@@ -143,6 +145,62 @@ impl ContainerRuntime {
             RuntimeKind::Docker => "Docker",
         }
     }
+
+    /// On rootless Podman, the default user-namespace mapping remaps the host
+    /// user to container UID 0, so pre-existing workspace files appear
+    /// root-owned inside the container and the agent hits `EACCES` on its first
+    /// write. There's no way to fix that from inside ai-pod without weakening
+    /// the namespace boundary, but `PODMAN_USERNS=keep-id` fixes it cleanly.
+    /// Detect the situation up front and print a one-line hint instead of
+    /// letting the user hit an opaque permission error later.
+    ///
+    /// Only fires for rootless Podman: the runtime is Podman, it's not a
+    /// dry-run, `PODMAN_USERNS` isn't already set, we're not running as root,
+    /// and `/etc/subuid` actually has a sub-UID range configured for the current
+    /// user (the precondition for rootless UID remapping — this avoids a false
+    /// positive for rootful Podman invoked by a non-root user).
+    pub fn warn_if_rootless_userns_mismatch(&self) {
+        if self.kind != RuntimeKind::Podman || self.dry_run {
+            return;
+        }
+        if env::var_os("PODMAN_USERNS").is_some() {
+            return;
+        }
+        // SAFETY: `getuid` is always safe to call and cannot fail.
+        let uid = unsafe { libc::getuid() };
+        if uid == 0 {
+            return;
+        }
+        let subuid = std::fs::read_to_string("/etc/subuid").ok();
+        let username = env::var("USER").ok();
+        if !subuid_range_configured(username.as_deref(), uid, subuid.as_deref()) {
+            return;
+        }
+        eprintln!(
+            "{} workspace files may appear root-owned inside the container \
+             (rootless Podman's default UID mapping).\n  \
+             Set {} before running ai-pod to fix this, e.g. `{}`.",
+            "warning:".yellow().bold(),
+            "PODMAN_USERNS=keep-id".bold(),
+            "PODMAN_USERNS=keep-id ai-pod".bold(),
+        );
+    }
+}
+
+/// Whether `/etc/subuid` configures a sub-UID range for the current user,
+/// keyed by either the numeric UID or the login name (both forms are valid in
+/// `subuid(5)`). A missing/unreadable file (`None`) defaults to `true` so the
+/// hint is surfaced rather than silently swallowed on the rootless-Podman hosts
+/// this targets.
+fn subuid_range_configured(username: Option<&str>, uid: u32, subuid: Option<&str>) -> bool {
+    let Some(contents) = subuid else {
+        return true;
+    };
+    let uid_str = uid.to_string();
+    contents.lines().any(|line| {
+        let field = line.split(':').next().unwrap_or("").trim();
+        !field.is_empty() && (field == uid_str || username.is_some_and(|u| field == u))
+    })
 }
 
 #[cfg(test)]
@@ -255,6 +313,50 @@ mod tests {
             let pv = kind.to_possible_value().unwrap();
             assert_eq!(pv.get_name(), kind.as_str());
         }
+    }
+
+    #[test]
+    fn subuid_range_matches_by_username_or_uid() {
+        let contents = "alice:100000:65536\n1000:200000:65536\n";
+        // Matches by login name.
+        assert!(subuid_range_configured(Some("alice"), 4242, Some(contents)));
+        // Matches by numeric uid even when the name differs.
+        assert!(subuid_range_configured(Some("bob"), 1000, Some(contents)));
+    }
+
+    #[test]
+    fn subuid_range_absent_for_unlisted_user() {
+        let contents = "alice:100000:65536\n";
+        assert!(!subuid_range_configured(Some("bob"), 4242, Some(contents)));
+        // No username available and uid not listed → not configured.
+        assert!(!subuid_range_configured(None, 4242, Some(contents)));
+    }
+
+    #[test]
+    fn subuid_range_missing_file_defaults_to_warning() {
+        // A missing/unreadable /etc/subuid should not suppress the hint on the
+        // rootless-Podman hosts this targets.
+        assert!(subuid_range_configured(Some("alice"), 1000, None));
+    }
+
+    #[test]
+    fn warn_userns_noop_for_docker() {
+        // Docker does not do rootless UID remapping the way this warns about;
+        // the guard clause must return before touching the environment.
+        let rt = ContainerRuntime {
+            kind: RuntimeKind::Docker,
+            dry_run: false,
+        };
+        rt.warn_if_rootless_userns_mismatch();
+    }
+
+    #[test]
+    fn warn_userns_noop_in_dry_run() {
+        let rt = ContainerRuntime {
+            kind: RuntimeKind::Podman,
+            dry_run: true,
+        };
+        rt.warn_if_rootless_userns_mismatch();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the detect-and-hint fix discussed in #128 for rootless Podman on Fedora and similar setups.

Rootless Podman's default user-namespace mapping remaps the host user to container UID 0, so pre-existing workspace files owned by the host user appear root-owned inside the container. The `ai-pod` agent (running as container UID 1000) then hits `EACCES` on its first write to any file it didn't create — e.g. `CLAUDE.md`. This surfaces a one-line hint pointing at `PODMAN_USERNS=keep-id` up front, rather than letting the user hit an opaque permission error later.

This is the minimal approach agreed on in the issue thread — no ACLs, no automatic remediation, no new dependencies. It just proactively surfaces the fix that's already documented in the [troubleshooting docs](https://ai-pod.apps.farbenmeer.de/#troubleshooting).

## Changes

- **`src/runtime.rs`**: Added `ContainerRuntime::warn_if_rootless_userns_mismatch()`. It fires only when the runtime is Podman, it's not a dry-run, `PODMAN_USERNS` isn't already set, the process UID isn't 0, and `/etc/subuid` has a sub-UID range configured for the current user (the real precondition for rootless UID remapping — avoids false positives for rootful Podman run as a non-root user). On match it prints:
  ```
  warning: workspace files may appear root-owned inside the container (rootless Podman's default UID mapping).
    Set PODMAN_USERNS=keep-id before running ai-pod to fix this, e.g. `PODMAN_USERNS=keep-id ai-pod`.
  ```
  Extracted a pure, testable `subuid_range_configured()` helper that matches by numeric UID or login name (both valid per `subuid(5)`) and defaults to warning when `/etc/subuid` is unreadable.
- **`src/container.rs`**: Wired the check into both container entry points — `launch_container` and `run_in_container`.
- Added unit tests covering the guard clauses (non-Podman, dry-run) and the `/etc/subuid`-parsing helper (match by name/uid, no matching entry, missing file).

## Testing

- `cargo build` — passes
- `cargo test runtime::` — 15 passed
- `cargo clippy` — no new warnings (one pre-existing warning in `cli.rs` is unrelated)

## Context

This recreates the change from the [Claude action on #128](https://github.com/mismosmi/ai-pod/actions/runs/30074990463) that couldn't push its commit — the workflow's `GITHUB_TOKEN` lacked `contents: write`, so `git push` returned `403: Permission to mismosmi/ai-pod.git denied to github-actions[bot]`, and no PR was opened.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSMMAKSBGbLQnZQhSv3yAj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSMMAKSBGbLQnZQhSv3yAj)_