### PR TITLE
fix: silence "could not find file" noise on first launch

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -571,7 +571,9 @@ fn refresh_claude_mcp_in_volume(
         anyhow::bail!("Failed to create mcp-refresh container");
     }
 
-    // Pull the existing .claude.json out of the volume (may not exist yet).
+    // Pull the existing .claude.json out of the volume (may not exist yet, so
+    // silence the runtime's "no such file" complaint — a missing config is the
+    // normal first-launch case and is handled by the empty-object default below).
     let tmp_in = config.config_dir.join("claude-in.json");
     let _ = std::fs::remove_file(&tmp_in);
     let _ = rt
@@ -581,6 +583,8 @@ fn refresh_claude_mcp_in_volume(
             &format!("{}:{}/.claude.json", init_container, CONTAINER_HOME),
             tmp_in.to_str().unwrap(),
         ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status();
 
     let mut value: serde_json::Value = std::fs::read_to_string(&tmp_in)
@@ -650,7 +654,9 @@ fn refresh_codex_config_in_volume(
         anyhow::bail!("Failed to create codex-refresh container");
     }
 
-    // Pull the existing config.toml out of the volume (may not exist yet).
+    // Pull the existing config.toml out of the volume (may not exist yet, so
+    // silence the runtime's "no such file" complaint — a missing config is the
+    // normal first-launch case and is handled by the empty-string default below).
     let tmp_in = config.config_dir.join("codex-config-in.toml");
     let _ = std::fs::remove_file(&tmp_in);
     let _ = rt
@@ -660,6 +666,8 @@ fn refresh_codex_config_in_volume(
             &format!("{}:{}/.codex/config.toml", init_container, CONTAINER_HOME),
             tmp_in.to_str().unwrap(),
         ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status();
 
     let existing = std::fs::read_to_string(&tmp_in).unwrap_or_default();


### PR DESCRIPTION
## Problem

Starting ai-pod against a fresh home volume prints what looks like a fatal error:

```
Error response from daemon: Could not find the file /home/ai-pod/.codex/config.toml in container ai-pod-HASH-codex
```

`refresh_codex_config_in_volume` probes the volume for `~/.codex/config.toml` with `cp` before merging ai-pod's MCP entry and `notify` settings into it. On a fresh volume that file doesn't exist yet, so the runtime writes the error above to stderr — which ai-pod inherits and shows to the user.

The failure is already handled: the exit status is discarded (`let _ = ...`) and the read falls back to an empty config via `unwrap_or_default()`. Only the leaked stderr is the problem. The subsequent write-back creates the file, so this appears once per new volume — enough to look like something is broken during first-run setup.

## Fix

Redirect stdout/stderr to null on the probe `cp`, matching the existing idiom in `volume_exists` (`src/container.rs:48`). The write-back `cp` is deliberately left untouched so a genuine failure there is still reported.

The `.claude.json` probe in `refresh_claude_mcp_in_volume` has the identical shape and the same latent noise when the host has no `~/.claude.json` to seed from, so it gets the same treatment.

## Verification

The environment this was developed in can't pull container images (egress policy blocks registry blob CDNs), so the full launch path wasn't exercised end-to-end. The specific behaviour was confirmed directly instead, using an empty image built locally via `docker import`:

```
$ docker cp probetest:/home/ai-pod/.codex/config.toml ./out.toml
Error response from daemon: Could not find the file /home/ai-pod/.codex/config.toml in container probetest
exit=1

$ docker cp probetest:/home/ai-pod/.codex/config.toml ./out.toml 2>/dev/null
exit=1
```

Exit status is unchanged (still 1, still ignored); only the message is suppressed.

- `cargo build` — clean
- `cargo test --lib --bins` — 213 passed, 0 failed
- `cargo clippy --all-targets` — no new warnings
- The e2e suite needs real containers and can't run here; the 9 failures in that suite are all image-pull related and predate this change.

Worth a sanity check on a machine with a working runtime, ideally against Podman as well as Docker, since the two word this error differently.