### PR TITLE
feat: inject an ai-pod skill and let the agent rebuild its own image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ai-pod"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ ai-pod manages per-workspace containers that run Claude Code, OpenCode, or OpenA
 - **Persistent agent state** — a named volume preserves `~/.claude`, `~/.config/opencode`, and `~/.codex` (login, memory, settings) across container restarts
 - **Credential scanning** — scans the workspace for secrets before mounting it; prompts you to review or abort
 - **Custom Dockerfiles per project** — drop an `ai-pod.Dockerfile` in any project to install extra runtimes, tools, or MCP servers
-- **AI-driven skill file** — container environment context and host-command usage are delivered via an auto-generated ai-pod skill loaded by Claude and OpenCode
+- **AI-driven skill file** — an `ai-pod` skill is written into every container so the agent can look up how the pod works (host commands, services, image rebuilds) on demand instead of carrying it in context
+- **Self-adjusting environment** — the agent can edit `ai-pod.Dockerfile` and verify it with the `rebuild_image` MCP tool, which rebuilds the image and smoke-tests it in a throwaway container
 - **Host command execution via MCP** — the in-container agent talks to the shared host server over MCP (`http://host.containers.internal:7822/mcp`); every host command requires your explicit approval with a persistent allowlist
 - **File-based command output** — every command writes stdout/stderr/exit to `{workspace}/.ai-pod/commands/{session_id}/{command_id}/` so the agent reads long-running output directly
 - **Interactive TUIs** — `ai-pod commands` to inspect/kill running host commands, `ai-pod allowed` to manage the whitelist
@@ -173,9 +174,40 @@ The default image is based on Ubuntu. The Dockerfile downloads the agent (Claude
 
 ---
 
+## The ai-pod skill
+
+Every container gets an `ai-pod` skill written into the home volume, at
+`~/.claude/skills/ai-pod/SKILL.md` (read by Claude Code and OpenCode) and
+`~/.codex/skills/ai-pod/SKILL.md` (read by Codex). It is refreshed on every
+launch, so upgrading ai-pod updates the instructions in existing volumes.
+
+Agents load a skill on demand, so the guidance costs nothing until the agent
+actually needs it. It covers:
+
+- **Where the agent is** — workspace at `/app`, a persistent `$HOME` volume,
+  everything else ephemeral, the host at `host.containers.internal` /
+  `host.docker.internal`.
+- **How to run host commands** — prefer the container; keep the command simple;
+  never pipe, redirect, or chain just to shape output, because the full streams
+  are already written to files the agent can read; don't `cd` to an absolute
+  path; reuse command strings verbatim so the user's allowlist keeps matching.
+- **How to stop them** — `stop_command` with the `command_id`, never `kill`,
+  `pkill` or `killall` on the host: those guess at pids on the user's machine
+  and can take out their editor, their dev server, or the session itself.
+- **Service containers** — reach for `start_service` instead of installing a
+  database into the pod.
+- **How to change the image** — edit `ai-pod.Dockerfile`, what must stay intact,
+  and how to verify the result with `rebuild_image`.
+
+Bind-mounting your own skills directory over the container's (e.g.
+`ai-pod mount add ~/.claude/skills`) hides the injected copy; ai-pod prints a
+warning at launch when a mount does that.
+
+---
+
 ## Host interaction
 
-The in-container agent talks to the host through an **MCP server** running on the shared ai-pod host server (`http://host.containers.internal:7822/mcp`, or `host.docker.internal` on Docker). No CLI binary is shipped into the container — host interaction happens entirely through MCP tools, taught to the agent via the auto-generated ai-pod skill.
+The in-container agent talks to the host through an **MCP server** running on the shared ai-pod host server (`http://host.containers.internal:7822/mcp`, or `host.docker.internal` on Docker). No CLI binary is shipped into the container — host interaction happens entirely through MCP tools, taught to the agent via the injected [ai-pod skill](#the-ai-pod-skill).
 
 ### MCP tools
 
@@ -185,12 +217,37 @@ The in-container agent talks to the host through an **MCP server** running on th
 | `command_status` | Check the status of a previously started command. Returns running/finished/killed plus the last 10 lines of stdout/stderr. |
 | `stop_command` | Stop a running command (SIGTERM, then SIGKILL after 5 s). |
 | `list_commands` | List commands for this session (or workspace-wide with `scope=workspace`). |
+| `rebuild_image` | Rebuild the workspace image from `ai-pod.Dockerfile` and run a test command in a throwaway container of the result. |
 | `notify_user` | Send a desktop notification to the host user. |
 | `list_allowed_commands` | List host commands previously approved by the user for this workspace. |
 | `start_service` | Start an auxiliary service container (e.g. `postgres:16`) reachable from inside the agent container. |
 | `stop_service` | Stop and remove a service container started by this session. |
 | `list_services` | List service containers started by this session. |
 | `service_logs` | Read the tail of a service container's logs. |
+
+### Rebuilding the image from inside the pod
+
+The agent can adjust its own environment: it edits `/app/ai-pod.Dockerfile` and
+then calls `rebuild_image` with a `test_command`.
+
+```jsonc
+{ "test_command": "node --version && npx playwright --version" }
+```
+
+The tool rebuilds the workspace image with the same build args and context the
+CLI uses and, **only if the build succeeds**, runs `test_command` in a throwaway
+container of the fresh image (`--rm`, no workspace mount) so the agent can prove
+the tools it added are installed and on `PATH`. Build log and test output stream
+to the usual command output files, so a long build is polled by re-reading
+`stdout` rather than by blocking.
+
+Rebuilds are approved like everything else, with their own per-workspace
+allowlist entry (`rebuild image <image> from ai-pod.Dockerfile`) that is
+independent of the test command — so approving once lets the agent iterate on
+its Dockerfile, and each rebuild is still just a container build on your machine.
+
+The **running container is not affected**: the new image is picked up the next
+time you start ai-pod.
 
 ### Service containers
 
@@ -286,6 +343,13 @@ The symlink target is outside the mount — the container never sees the actual 
 ### Host command approval
 
 Claude can only run host commands you have explicitly approved via the interactive prompt. Approved commands are persisted per-workspace so you only approve each one once. The MCP server pre-rejects obviously dangerous patterns (e.g. starting with `cd /`, piping to `| head`/`| tail`) before they reach the approval dialog.
+
+Service starts and image rebuilds are approved the same way, in their own
+per-workspace buckets: a service is keyed by image plus the sorted list of
+env-var KEY names, a rebuild by the image name. Approving one never implies the
+others — an always-allowed `make build` does not let the agent rebuild its
+image, and an always-allowed rebuild does not let it run arbitrary host
+commands.
 
 ---
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -192,6 +192,17 @@ pub(crate) fn build_mount_args(home_dir: &Path, mounts: &[MountSpec]) -> Result<
             );
             continue;
         }
+        // A mount over a skills directory hides the ai-pod skill ai-pod writes
+        // into the home volume, leaving the agent without the host-interaction
+        // instructions. Benign enough to allow, noisy enough to say so.
+        if let Some(skill) = crate::skill::shadowed_path(CONTAINER_HOME, &target) {
+            eprintln!(
+                "{} mount {} hides the injected ai-pod skill at {}; the agent will not see it",
+                "warning:".yellow().bold(),
+                target,
+                skill
+            );
+        }
         let opts = if m.writable { "z" } else { "z,ro" };
         out.push("-v".to_string());
         out.push(format!("{}:{}:{}", m.host, target, opts));
@@ -690,6 +701,72 @@ fn refresh_codex_config_in_volume(
     Ok(())
 }
 
+/// Write the `ai-pod` agent skill into the home volume.
+///
+/// Runs on every launch (not just on seed) so an ai-pod upgrade refreshes the
+/// instructions in long-lived volumes, mirroring the MCP-config refreshes
+/// above. The file is dropped into every agent's global skills directory; the
+/// agent loads it on demand instead of carrying the guidance in its context.
+pub fn refresh_skill_in_volume(
+    rt: &ContainerRuntime,
+    config: &AppConfig,
+    volume_name: &str,
+    container_name: &str,
+    image: &str,
+) -> Result<()> {
+    let skill_file = config.config_dir.join("ai-pod-skill.md");
+    std::fs::write(&skill_file, crate::skill::render(rt))
+        .context("Failed to render ai-pod skill")?;
+
+    let mut mkdir = rt.command();
+    mkdir.args([
+        "run",
+        "--rm",
+        "-v",
+        &format!("{}:{}:z", volume_name, CONTAINER_HOME),
+        image,
+        "mkdir",
+        "-p",
+    ]);
+    for dir in crate::skill::skill_dirs(CONTAINER_HOME) {
+        mkdir.arg(dir);
+    }
+    let _ = mkdir.status();
+
+    let init_container = format!("{}-skill", container_name);
+    let status = rt
+        .command()
+        .args([
+            "create",
+            "--name",
+            &init_container,
+            "-v",
+            &format!("{}:{}", volume_name, CONTAINER_HOME),
+            image,
+            "true",
+        ])
+        .status()
+        .context("Failed to create skill-refresh container")?;
+    if !status.success() {
+        anyhow::bail!("Failed to create skill-refresh container");
+    }
+
+    for path in crate::skill::skill_paths(CONTAINER_HOME) {
+        let _ = rt
+            .command()
+            .args([
+                "cp",
+                &skill_file.to_string_lossy(),
+                &format!("{}:{}", init_container, path),
+            ])
+            .status();
+    }
+
+    let _ = rt.command().args(["rm", &init_container]).status();
+    let _ = std::fs::remove_file(&skill_file);
+    Ok(())
+}
+
 /// Initialize a named home volume for the first time.
 fn init_home_volume(
     rt: &ContainerRuntime,
@@ -831,6 +908,8 @@ pub fn launch_container(
         &session_id,
     )?;
 
+    refresh_skill_in_volume(rt, config, &volume_name, &prefix, image)?;
+
     let add_host = rt.add_host_arg();
     let host_gw_env = format!("HOST_GATEWAY={}", rt.host_gateway());
     let server_url_env = format!("AI_POD_SERVER_URL={}", rt.server_url());
@@ -961,6 +1040,8 @@ pub fn run_in_container(
         api_key,
         &session_id,
     )?;
+
+    refresh_skill_in_volume(rt, config, &volume_name, &container_name, image)?;
 
     eprintln!(
         "{} {} {}",

--- a/src/image.rs
+++ b/src/image.rs
@@ -37,6 +37,65 @@ pub fn image_name(workspace: &Path) -> String {
     format!("{}-{}", label, short_hash)
 }
 
+/// Quote a string for safe inclusion in a `sh -c` command line.
+fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+/// The shell form of the image build, for callers that run it through the
+/// file-based command runner instead of inheriting stdio (see the
+/// `rebuild_image` MCP tool). Mirrors the arguments used by [`build_image`].
+fn build_command_string(
+    rt: &ContainerRuntime,
+    dockerfile: &Path,
+    image: &str,
+    no_cache: bool,
+) -> String {
+    let context = dockerfile.parent().unwrap_or(Path::new("."));
+    let mut parts = vec![rt.cmd().to_string(), "build".to_string()];
+    if no_cache {
+        parts.push("--no-cache".to_string());
+    }
+    // Docker build containers don't get the host gateway for free.
+    if rt.kind == crate::runtime::RuntimeKind::Docker {
+        parts.push(sh_quote(&rt.add_host_arg()));
+    }
+    parts.extend([
+        "--build-arg".to_string(),
+        sh_quote(&format!("AI_POD_VERSION={}", env!("CARGO_PKG_VERSION"))),
+        "--build-arg".to_string(),
+        sh_quote(&format!("HOST_GATEWAY={}", rt.host_gateway())),
+        "-t".to_string(),
+        sh_quote(image),
+        "-f".to_string(),
+        sh_quote(&dockerfile.to_string_lossy()),
+        sh_quote(&context.to_string_lossy()),
+    ]);
+    parts.join(" ")
+}
+
+/// Build the image, then — only if the build succeeded — run `test_command` in
+/// a throwaway container of the freshly built image so the caller can verify
+/// the tools it asked for are actually installed. The workspace is not
+/// mounted: this checks the *image*, not the project.
+pub fn rebuild_and_test_command(
+    rt: &ContainerRuntime,
+    dockerfile: &Path,
+    image: &str,
+    no_cache: bool,
+    test_command: &str,
+) -> String {
+    let build = build_command_string(rt, dockerfile, image, no_cache);
+    let test = format!(
+        "{} run --rm {} --entrypoint sh {} -c {}",
+        rt.cmd(),
+        sh_quote(&rt.add_host_arg()),
+        sh_quote(image),
+        sh_quote(test_command),
+    );
+    format!("{build} && {test}")
+}
+
 fn image_exists(rt: &ContainerRuntime, image: &str) -> Result<bool> {
     let status = rt
         .command()
@@ -186,6 +245,93 @@ mod tests {
         let a = image_name(Path::new("/alice/code/myproject"));
         let b = image_name(Path::new("/bob/code/myproject"));
         assert_ne!(a, b);
+    }
+
+    fn test_rt(kind: crate::runtime::RuntimeKind) -> ContainerRuntime {
+        ContainerRuntime {
+            kind,
+            dry_run: false,
+        }
+    }
+
+    #[test]
+    fn sh_quote_escapes_embedded_single_quotes() {
+        assert_eq!(sh_quote("it's"), r#"'it'\''s'"#);
+        assert_eq!(sh_quote("plain"), "'plain'");
+    }
+
+    #[test]
+    fn rebuild_command_builds_then_tests_the_fresh_image() {
+        use crate::runtime::RuntimeKind;
+        let cmd = rebuild_and_test_command(
+            &test_rt(RuntimeKind::Podman),
+            Path::new("/ws/ai-pod.Dockerfile"),
+            "ws-abc123",
+            false,
+            "node --version",
+        );
+        let (build, test) = cmd.split_once(" && ").expect("build must gate the test");
+        assert!(build.starts_with("podman build "));
+        assert!(build.contains("-t 'ws-abc123'"));
+        assert!(build.contains("-f '/ws/ai-pod.Dockerfile'"));
+        // Build context is the Dockerfile's directory.
+        assert!(
+            build.ends_with(" '/ws'"),
+            "unexpected build context: {build}"
+        );
+        assert!(build.contains("--build-arg 'HOST_GATEWAY=host.containers.internal'"));
+        assert!(build.contains(&format!(
+            "--build-arg 'AI_POD_VERSION={}'",
+            env!("CARGO_PKG_VERSION")
+        )));
+        assert!(!build.contains("--no-cache"));
+        // Throwaway container, no workspace mount, test command quoted as one arg.
+        assert!(test.starts_with("podman run --rm "));
+        assert!(test.contains("--entrypoint sh 'ws-abc123' -c 'node --version'"));
+        assert!(!test.contains("-v "));
+    }
+
+    #[test]
+    fn rebuild_command_honours_no_cache() {
+        use crate::runtime::RuntimeKind;
+        let cmd = rebuild_and_test_command(
+            &test_rt(RuntimeKind::Podman),
+            Path::new("/ws/ai-pod.Dockerfile"),
+            "img",
+            true,
+            "true",
+        );
+        assert!(cmd.contains("podman build --no-cache "));
+    }
+
+    #[test]
+    fn rebuild_command_adds_host_gateway_for_docker_builds() {
+        use crate::runtime::RuntimeKind;
+        let cmd = rebuild_and_test_command(
+            &test_rt(RuntimeKind::Docker),
+            Path::new("/ws/ai-pod.Dockerfile"),
+            "img",
+            false,
+            "true",
+        );
+        assert!(cmd.contains("docker build '--add-host=host.docker.internal:host-gateway'"));
+    }
+
+    #[test]
+    fn rebuild_command_quotes_a_hostile_test_command() {
+        use crate::runtime::RuntimeKind;
+        let cmd = rebuild_and_test_command(
+            &test_rt(RuntimeKind::Podman),
+            Path::new("/ws/ai-pod.Dockerfile"),
+            "img",
+            false,
+            "echo hi'; rm -rf /tmp/x; echo '",
+        );
+        // The injected shell metacharacters stay inside a single quoted argument.
+        assert!(
+            cmd.ends_with(r#"-c 'echo hi'\''; rm -rf /tmp/x; echo '\'''"#),
+            "got: {cmd}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod runtime;
 pub mod server;
 pub mod service;
 pub mod services_cli;
+pub mod skill;
 pub mod update;
 pub mod workspace;
 

--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -341,6 +341,53 @@ pub async fn run_service_request(
     }
 }
 
+/// Canonical string that identifies a `rebuild_image` request for approval
+/// purposes. The test command is deliberately *not* part of the key: it runs
+/// inside a throwaway container of the freshly built image, so the thing the
+/// user is really approving is "this workspace's agent may rebuild its own
+/// image from its Dockerfile".
+pub fn rebuild_approval_key(image: &str) -> String {
+    format!(
+        "rebuild image {} from {}",
+        image,
+        crate::image::DOCKERFILE_NAME
+    )
+}
+
+/// Approve (or pre-approve) an image-rebuild request. Mirrors
+/// `run_service_request` but consults `allowed_rebuilds`.
+pub async fn run_rebuild_request(
+    state: &AppState,
+    image: &str,
+    workspace: &Path,
+) -> ApprovalOutcome {
+    let key = rebuild_approval_key(image);
+    let hash = workspace_hash(workspace);
+    let state_file = state.config_dir.join(format!("{}.json", hash));
+    let ps = ProjectState::load(&state_file);
+    if ps.is_rebuild_allowed(&key) {
+        return ApprovalOutcome::Approved;
+    }
+
+    let project_name = workspace
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let body = format!("Rebuild container image:\n{}", key);
+    match request_approval_with_body(state, body, &key, &project_name).await {
+        ApprovalDecision::AllowOnce => ApprovalOutcome::Approved,
+        ApprovalDecision::AlwaysAllow => {
+            let mut ps = ProjectState::load(&state_file);
+            ps.add_allowed_rebuild(&key);
+            let _ = ps.save(&state_file);
+            ApprovalOutcome::AlwaysAllow
+        }
+        ApprovalDecision::Deny(reason) => ApprovalOutcome::Denied(reason),
+        ApprovalDecision::PermissionTimeout => ApprovalOutcome::Timeout,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -401,6 +448,38 @@ mod tests {
         assert_eq!(args[2], "--");
         assert_eq!(args[3], "-e malicious_script");
         assert_eq!(args[4], "--version");
+    }
+
+    #[test]
+    fn rebuild_key_names_the_image_and_dockerfile() {
+        let key = rebuild_approval_key("myproject-12aef3");
+        assert!(key.contains("myproject-12aef3"));
+        assert!(key.contains("ai-pod.Dockerfile"));
+    }
+
+    #[test]
+    fn rebuild_key_is_independent_of_the_test_command() {
+        // The key is what lands in the allowlist; it must stay stable so the
+        // agent can iterate on its Dockerfile without re-prompting per test.
+        assert_eq!(rebuild_approval_key("img"), rebuild_approval_key("img"));
+        assert_ne!(rebuild_approval_key("img"), rebuild_approval_key("other"));
+    }
+
+    #[test]
+    fn rebuild_allowlist_round_trips_through_project_state() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("state.json");
+        let key = rebuild_approval_key("img");
+        let mut ps = ProjectState::default();
+        assert!(!ps.is_rebuild_allowed(&key));
+        ps.add_allowed_rebuild(&key);
+        ps.add_allowed_rebuild(&key);
+        ps.save(&path).unwrap();
+        let loaded = ProjectState::load(&path);
+        assert_eq!(loaded.allowed_rebuilds, vec![key.clone()]);
+        assert!(loaded.is_rebuild_allowed(&key));
+        // Rebuild approval is its own bucket — it must not leak into commands.
+        assert!(!loaded.is_allowed(&key));
     }
 
     #[test]

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -42,6 +42,10 @@ pub struct ProjectState {
     /// `start_service` requests. See `commands::service_approval_key`.
     #[serde(default)]
     pub allowed_services: Vec<String>,
+    /// Image names the user has approved for `rebuild_image` requests. See
+    /// `commands::rebuild_approval_key`.
+    #[serde(default)]
+    pub allowed_rebuilds: Vec<String>,
 }
 
 impl ProjectState {
@@ -119,6 +123,16 @@ impl ProjectState {
     pub fn add_allowed_service(&mut self, key: &str) {
         if !self.is_service_allowed(key) {
             self.allowed_services.push(key.to_string());
+        }
+    }
+
+    pub fn is_rebuild_allowed(&self, key: &str) -> bool {
+        self.allowed_rebuilds.iter().any(|k| k == key)
+    }
+
+    pub fn add_allowed_rebuild(&mut self, key: &str) {
+        if !self.is_rebuild_allowed(key) {
+            self.allowed_rebuilds.push(key.to_string());
         }
     }
 }
@@ -376,6 +390,7 @@ mod tests {
             ignored_credential_files: vec![],
             masked_directories: vec![],
             allowed_services: vec![],
+            allowed_rebuilds: vec![],
         };
         state.save(&path).unwrap();
         let perms = std::fs::metadata(&path).unwrap().permissions();
@@ -411,6 +426,7 @@ mod tests {
             ignored_credential_files: vec![],
             masked_directories: vec![],
             allowed_services: vec![],
+            allowed_rebuilds: vec![],
         };
         state.save(&path).unwrap();
         let loaded = ProjectState::load(&path);

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -83,7 +83,7 @@ fn tool_error(text: String) -> Value {
 
 fn tools_definition(runtime: &ContainerRuntime) -> Value {
     let run_command_description = format!(
-        "Run a shell command on the host (outside this container). From inside the container, reach host services via `{}` instead of `localhost`. Waits up to 5 seconds; returns the result inline if finished, otherwise returns a command_id for polling.\n\nOutput goes to `/app/.ai-pod/commands/{{session_id}}/{{command_id}}/{{stdout,stderr,exit}}` — these files live on THIS container's filesystem (the workspace is mounted at `/app`). Read them with your regular file Read tool, not via bash on the host. Re-Read `stdout`/`exit` to poll progress; you do not need to keep calling `command_status`.\n\nDo not start commands with `cd /`. Do not pipe to `| head`/`| tail` on the host — trim output in the container instead. Keep commands as simple as possible.",
+        "Run a shell command on the host (outside this container). From inside the container, reach host services via `{}` instead of `localhost`. Waits up to 5 seconds; returns the result inline if finished, otherwise returns a command_id for polling.\n\nOutput goes to `/app/.ai-pod/commands/{{session_id}}/{{command_id}}/{{stdout,stderr,exit}}` — these files live on THIS container's filesystem (the workspace is mounted at `/app`). Read them with your regular file Read tool, not via bash on the host. Re-Read `stdout`/`exit` to poll progress; you do not need to keep calling `command_status`.\n\nKeep the command simple: one command, plain arguments. Do not pipe, redirect, or chain — the full output is written to the files above anyway, so `| head`/`| tail` (rejected outright), `| grep`, `> file` and `2>&1` gain you nothing. Do not start commands with `cd /` either; commands already start in the workspace root. Load the `ai-pod` skill for the full rules.",
         runtime.host_gateway(),
     );
     json!([
@@ -107,7 +107,7 @@ fn tools_definition(runtime: &ContainerRuntime) -> Value {
         },
         {
             "name": "stop_command",
-            "description": "Stop a running command (SIGTERM, then SIGKILL after 5s).",
+            "description": "Stop a running command (SIGTERM, then SIGKILL after 5s) — the whole process group, so use this instead of running `kill`/`pkill` on the host.",
             "inputSchema": {
                 "type": "object",
                 "properties": { "command_id": { "type": "string" } },
@@ -122,6 +122,24 @@ fn tools_definition(runtime: &ContainerRuntime) -> Value {
                 "properties": {
                     "scope": { "type": "string", "enum": ["session", "workspace"] }
                 }
+            }
+        },
+        {
+            "name": "rebuild_image",
+            "description": "Rebuild this workspace's container image from `/app/ai-pod.Dockerfile` and, if the build succeeds, run `test_command` in a throwaway container of the fresh image so you can verify the tools you added are installed. The throwaway container is removed immediately and does NOT have the workspace mounted — test for tools, not for project builds.\n\nEdit `/app/ai-pod.Dockerfile` first; keep the agent install line, `WORKDIR /app`, the `ai-pod` user and the final `CMD` intact. Build log and test output go to `/app/.ai-pod/commands/{session_id}/{command_id}/{stdout,stderr,exit}` like any other command — read them with your file Read tool. A non-zero `exit` means the build or the test failed.\n\nThe running container is NOT changed: the new image is picked up the next time the user starts ai-pod. Use this instead of running `podman build`/`docker build` via run_command. See the `ai-pod` skill for the full workflow.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "test_command": {
+                        "type": "string",
+                        "description": "Shell command run in a throwaway container of the freshly built image, e.g. `node --version && npx playwright --version`."
+                    },
+                    "no_cache": {
+                        "type": "boolean",
+                        "description": "Build without the layer cache (default false). Slow — only when a cached layer is stale."
+                    }
+                },
+                "required": ["test_command"]
             }
         },
         {
@@ -251,6 +269,77 @@ pub async fn mcp_handler(
                 Json(rpc_error(id, -32601, &format!("Unknown method: {method}"))).into_response()
             }
         }
+    }
+}
+
+/// Rebuild the workspace image from its `ai-pod.Dockerfile`, then smoke-test
+/// the result in a throwaway container. Runs through the normal command runner
+/// so the (long) build log lands in the usual output files and the agent can
+/// poll or `stop_command` it like anything else.
+async fn handle_rebuild_image(
+    state: &AppState,
+    rt: &ContainerRuntime,
+    workspace: &std::path::Path,
+    session_id: &str,
+    args: &Value,
+) -> Value {
+    let test_command = match args.get("test_command").and_then(|v| v.as_str()) {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => {
+            return tool_error(
+                "Missing `test_command` — pass a command that proves the tools you need are installed, e.g. `node --version`.".into(),
+            );
+        }
+    };
+    let no_cache = args
+        .get("no_cache")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let dockerfile = workspace.join(crate::image::DOCKERFILE_NAME);
+    if !dockerfile.exists() {
+        return tool_error(format!(
+            "No {} in this workspace ({}). Create one with `ai-pod init` on the host first.",
+            crate::image::DOCKERFILE_NAME,
+            workspace.display()
+        ));
+    }
+    let image = crate::image::image_name(workspace);
+
+    match commands::run_rebuild_request(state, &image, workspace).await {
+        commands::ApprovalOutcome::Denied(reason) => return tool_error(reason.message().into()),
+        commands::ApprovalOutcome::Timeout => {
+            return tool_error("Permission request timed out after 60 seconds.".into());
+        }
+        commands::ApprovalOutcome::Rejected => {
+            return tool_error("Image rebuild rejected".into());
+        }
+        commands::ApprovalOutcome::Approved | commands::ApprovalOutcome::AlwaysAllow => {}
+    }
+
+    let cmd =
+        crate::image::rebuild_and_test_command(rt, &dockerfile, &image, no_cache, test_command);
+    match runner::spawn_and_wait(state, workspace, session_id, &cmd).await {
+        Ok(mut outcome) => {
+            let (s, e, x) = runner::container_paths(&outcome.session_id, &outcome.command_id);
+            outcome.stdout_path = s;
+            outcome.stderr_path = e;
+            outcome.exit_path = x;
+            json!({
+                "content": [{
+                    "type": "text",
+                    "text": format!(
+                        "Rebuilding `{}` from {}; the test command runs in a throwaway container once the build succeeds. The image change takes effect the next time the user starts ai-pod.\n{}",
+                        image,
+                        crate::image::DOCKERFILE_NAME,
+                        serde_json::to_string_pretty(&outcome).unwrap_or_default()
+                    )
+                }],
+                "isError": false,
+                "structuredContent": outcome,
+            })
+        }
+        Err(e) => tool_error(format!("Failed to start rebuild: {e}")),
     }
 }
 
@@ -556,6 +645,66 @@ mod tests {
     }
 
     #[test]
+    fn tools_definition_includes_rebuild_image() {
+        let v = tools_definition(&test_runtime(RuntimeKind::Podman));
+        let desc = v
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|t| t["name"] == "rebuild_image")
+            .expect("rebuild_image tool must be advertised")["description"]
+            .as_str()
+            .unwrap();
+        assert!(
+            desc.contains("ai-pod.Dockerfile"),
+            "should name the Dockerfile it rebuilds, got: {desc}"
+        );
+        assert!(
+            desc.contains("throwaway container"),
+            "should explain where the test command runs, got: {desc}"
+        );
+        assert!(
+            desc.contains("next time"),
+            "should warn that the running container is unaffected, got: {desc}"
+        );
+    }
+
+    #[test]
+    fn rebuild_image_requires_a_test_command() {
+        let v = tools_definition(&test_runtime(RuntimeKind::Podman));
+        let tool = v
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|t| t["name"] == "rebuild_image")
+            .unwrap()
+            .clone();
+        assert_eq!(tool["inputSchema"]["required"][0], "test_command");
+    }
+
+    #[test]
+    fn run_command_description_forbids_output_shaping() {
+        let v = tools_definition(&test_runtime(RuntimeKind::Podman));
+        let desc = v[0]["description"].as_str().unwrap();
+        assert!(desc.contains("| head"), "got: {desc}");
+        assert!(desc.contains("Do not pipe"), "got: {desc}");
+    }
+
+    #[test]
+    fn stop_command_description_steers_away_from_host_kills() {
+        let v = tools_definition(&test_runtime(RuntimeKind::Podman));
+        let desc = v
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|t| t["name"] == "stop_command")
+            .unwrap()["description"]
+            .as_str()
+            .unwrap();
+        assert!(desc.contains("pkill"), "got: {desc}");
+    }
+
+    #[test]
     fn tools_definition_includes_service_tools() {
         let v = tools_definition(&test_runtime(RuntimeKind::Podman));
         let names: Vec<&str> = v
@@ -732,6 +881,7 @@ async fn handle_tool_call(
                 "structuredContent": { "commands": cmds },
             })
         }
+        "rebuild_image" => handle_rebuild_image(state, rt, workspace, session_id, &args).await,
         "start_service" => handle_start_service(state, rt, workspace, session_id, &args).await,
         "stop_service" => handle_stop_service(rt, workspace, session_id, &args).await,
         "list_services" => handle_list_services(rt, workspace, session_id).await,

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -1,0 +1,167 @@
+//! The `ai-pod` agent skill injected into every container.
+//!
+//! Rather than spending tokens on a permanently-loaded preamble, ai-pod ships
+//! a single skill file that agents load on demand. It teaches the in-container
+//! agent how to use the MCP host bridge (and how *not* to: no output piping,
+//! no `pkill` on the host) and how to change the image via `ai-pod.Dockerfile`.
+
+use crate::image::DOCKERFILE_NAME;
+use crate::runtime::ContainerRuntime;
+
+const SKILL_TEMPLATE: &str = include_str!("../templates/ai-pod-skill.md");
+
+/// Skill directory name — the agent sees the skill as `ai-pod`.
+pub const SKILL_NAME: &str = "ai-pod";
+
+/// Directories (relative to the container home) that agents scan for global
+/// skills. Claude Code and OpenCode both read `~/.claude/skills`; Codex reads
+/// `~/.codex/skills`. One small file in each is cheaper than detecting which
+/// agent the workspace's Dockerfile ends up running.
+pub const SKILL_DIRS: &[&str] = &[".claude/skills", ".codex/skills"];
+
+/// Absolute in-container paths of the skill file, one per agent skill dir.
+pub fn skill_paths(container_home: &str) -> Vec<String> {
+    SKILL_DIRS
+        .iter()
+        .map(|dir| format!("{container_home}/{dir}/{SKILL_NAME}/SKILL.md"))
+        .collect()
+}
+
+/// In-container directories that must exist before the skill file is copied in.
+pub fn skill_dirs(container_home: &str) -> Vec<String> {
+    SKILL_DIRS
+        .iter()
+        .map(|dir| format!("{container_home}/{dir}/{SKILL_NAME}"))
+        .collect()
+}
+
+/// The skill path a bind-mount at `target` would hide, if any.
+///
+/// Mounting the host's own `~/.claude/skills` into the container is an
+/// advertised use case, and it shadows the copy ai-pod writes into the home
+/// volume — the agent then has no idea how to talk to the host. Callers use
+/// this to warn instead of failing silently.
+pub fn shadowed_path(container_home: &str, target: &str) -> Option<String> {
+    let target = target.trim_end_matches('/');
+    skill_paths(container_home)
+        .into_iter()
+        .find(|p| p == target || p.starts_with(&format!("{target}/")))
+}
+
+/// Render the skill for a given runtime (the host gateway hostname differs
+/// between podman and docker).
+pub fn render(rt: &ContainerRuntime) -> String {
+    SKILL_TEMPLATE
+        .replace("{{HOST_GATEWAY}}", rt.host_gateway())
+        .replace("{{DOCKERFILE}}", DOCKERFILE_NAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::RuntimeKind;
+
+    fn rt(kind: RuntimeKind) -> ContainerRuntime {
+        ContainerRuntime {
+            kind,
+            dry_run: false,
+        }
+    }
+
+    #[test]
+    fn render_substitutes_every_placeholder() {
+        let s = render(&rt(RuntimeKind::Podman));
+        assert!(
+            !s.contains("{{"),
+            "unsubstituted placeholder left in skill: {s}"
+        );
+    }
+
+    #[test]
+    fn render_uses_the_runtimes_host_gateway() {
+        assert!(render(&rt(RuntimeKind::Podman)).contains("host.containers.internal"));
+        assert!(render(&rt(RuntimeKind::Docker)).contains("host.docker.internal"));
+    }
+
+    #[test]
+    fn skill_starts_with_frontmatter_naming_the_skill() {
+        let s = render(&rt(RuntimeKind::Podman));
+        assert!(s.starts_with("---\n"), "skill must open with frontmatter");
+        let end = s[4..].find("\n---").expect("frontmatter must be closed");
+        let frontmatter = &s[4..4 + end];
+        assert!(frontmatter.contains("name: ai-pod"));
+        assert!(frontmatter.contains("description:"));
+    }
+
+    #[test]
+    fn skill_teaches_the_host_command_constraints() {
+        let s = render(&rt(RuntimeKind::Podman));
+        // Simple commands, no output shaping — output is already in files.
+        assert!(s.contains("| head"), "should call out piping to head/tail");
+        assert!(s.contains("/app/.ai-pod/commands/"));
+        // Stopping goes through the MCP tool, not host signals.
+        assert!(s.contains("stop_command"));
+        assert!(s.contains("pkill"));
+    }
+
+    #[test]
+    fn skill_documents_dockerfile_edits_and_rebuild() {
+        let s = render(&rt(RuntimeKind::Podman));
+        assert!(s.contains(DOCKERFILE_NAME));
+        assert!(s.contains("rebuild_image"));
+        assert!(s.contains("test_command"));
+    }
+
+    #[test]
+    fn skill_paths_cover_claude_and_codex() {
+        let paths = skill_paths("/home/ai-pod");
+        assert!(paths.contains(&"/home/ai-pod/.claude/skills/ai-pod/SKILL.md".to_string()));
+        assert!(paths.contains(&"/home/ai-pod/.codex/skills/ai-pod/SKILL.md".to_string()));
+    }
+
+    #[test]
+    fn shadowed_path_flags_mounts_that_hide_the_skill() {
+        // The advertised `~/.claude/skills` mount hides the injected skill.
+        assert_eq!(
+            shadowed_path("/home/ai-pod", "/home/ai-pod/.claude/skills"),
+            Some("/home/ai-pod/.claude/skills/ai-pod/SKILL.md".to_string())
+        );
+        // Trailing slash, the skill's own directory, and the file itself too.
+        assert!(shadowed_path("/home/ai-pod", "/home/ai-pod/.claude/skills/").is_some());
+        assert!(shadowed_path("/home/ai-pod", "/home/ai-pod/.claude/skills/ai-pod").is_some());
+        assert!(
+            shadowed_path(
+                "/home/ai-pod",
+                "/home/ai-pod/.claude/skills/ai-pod/SKILL.md"
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn shadowed_path_ignores_unrelated_mounts() {
+        assert_eq!(
+            shadowed_path("/home/ai-pod", "/home/ai-pod/.claude/agents"),
+            None
+        );
+        // A sibling skill directory is not the ai-pod skill.
+        assert_eq!(
+            shadowed_path("/home/ai-pod", "/home/ai-pod/.claude/skills/other"),
+            None
+        );
+        // Prefix-of-a-path-segment must not count as a parent directory.
+        assert_eq!(
+            shadowed_path("/home/ai-pod", "/home/ai-pod/.claude/skill"),
+            None
+        );
+    }
+
+    #[test]
+    fn skill_dirs_are_the_parents_of_skill_paths() {
+        let dirs = skill_dirs("/home/ai-pod");
+        for path in skill_paths("/home/ai-pod") {
+            let parent = path.trim_end_matches("/SKILL.md").to_string();
+            assert!(dirs.contains(&parent), "missing mkdir target for {path}");
+        }
+    }
+}

--- a/templates/ai-pod-skill.md
+++ b/templates/ai-pod-skill.md
@@ -1,6 +1,6 @@
 ---
 name: ai-pod
-description: How to work inside an ai-pod container — running commands on the host with the ai-pod MCP tools, reading their output files, stopping them with stop_command, starting service containers, and changing the container image by editing {{DOCKERFILE}} and calling rebuild_image. Use whenever something has to run on the host, a host command hangs or has to be stopped, a tool or runtime is missing from this container, or the user asks about ai-pod itself.
+description: How to work inside an ai-pod container — running commands on the host and adjusting the container environment.
 ---
 
 # Working inside an ai-pod
@@ -14,10 +14,10 @@ container runtime itself) is reachable only through the `ai-pod` MCP server.
 - **The workspace is mounted at `/app`.** Files you write there land on the
   user's real filesystem. `/app` is where you do normal work.
 - **`$HOME` is a persistent volume.** Agent config and login survive restarts.
-  It is *not* the user's home directory.
+  It is _not_ the user's home directory.
 - **Everything else in the container is ephemeral.** Packages you install at
   runtime disappear when the session ends. To make a tool permanent, edit
-  `{{DOCKERFILE}}` (see *Changing this container* below).
+  `{{DOCKERFILE}}` (see _Changing this container_ below).
 - **The host is `{{HOST_GATEWAY}}`, not `localhost`.** A dev server the user
   runs on their machine is at `{{HOST_GATEWAY}}:<port>` from in here.
 
@@ -36,8 +36,8 @@ Rules, in order of how often they matter:
    pipelines, do not redirect, do not chain with `&&` or `;`, and do not wrap
    things in `bash -c "..."` to shape the output.
 3. **Never trim output on the host.** stdout and stderr are captured to files
-   you can read in full (see below), so `| head`, `| tail`, `| grep`, `> file`
-   and `2>&1` buy you nothing — `| head` and `| tail` are rejected outright.
+   you can read in full (see below), so `| head`, `| tail`, `| grep` and `> file`
+   buy you nothing — `| head` and `| tail` are rejected outright.
    Run the plain command and read as much of the output file as you need.
 4. **Don't `cd` to an absolute path first.** Host commands already start in the
    workspace root, and a leading `cd /…` is rejected. A relative `cd sub && …`
@@ -57,7 +57,7 @@ Rules, in order of how often they matter:
 /app/.ai-pod/commands/{session_id}/{command_id}/exit
 ```
 
-These are files in *this* container (the workspace is mounted at `/app`), so
+These are files in _this_ container (the workspace is mounted at `/app`), so
 read them with your normal file Read tool — not with a host command. Re-read
 `stdout` to follow progress and `exit` to see whether it is done: it contains
 the decimal exit code, or `killed`. `command_status` is there for a quick
@@ -101,7 +101,7 @@ Keep these intact:
 - `WORKDIR /app`, the `ai-pod` user creation, `USER ai-pod`, and the final
   `CMD`.
 
-Put root-level installs (`apt-get install …`, toolchains) *before* the
+Put root-level installs (`apt-get install …`, toolchains) _before_ the
 `USER ai-pod` line and user-level installs after it.
 
 Then verify with the `rebuild_image` MCP tool:

--- a/templates/ai-pod-skill.md
+++ b/templates/ai-pod-skill.md
@@ -1,0 +1,128 @@
+---
+name: ai-pod
+description: How to work inside an ai-pod container — running commands on the host with the ai-pod MCP tools, reading their output files, stopping them with stop_command, starting service containers, and changing the container image by editing {{DOCKERFILE}} and calling rebuild_image. Use whenever something has to run on the host, a host command hangs or has to be stopped, a tool or runtime is missing from this container, or the user asks about ai-pod itself.
+---
+
+# Working inside an ai-pod
+
+You are running in an ai-pod: a container dedicated to this workspace. Anything
+outside the container (the user's machine, their browser, other repos, the
+container runtime itself) is reachable only through the `ai-pod` MCP server.
+
+## Where you are
+
+- **The workspace is mounted at `/app`.** Files you write there land on the
+  user's real filesystem. `/app` is where you do normal work.
+- **`$HOME` is a persistent volume.** Agent config and login survive restarts.
+  It is *not* the user's home directory.
+- **Everything else in the container is ephemeral.** Packages you install at
+  runtime disappear when the session ends. To make a tool permanent, edit
+  `{{DOCKERFILE}}` (see *Changing this container* below).
+- **The host is `{{HOST_GATEWAY}}`, not `localhost`.** A dev server the user
+  runs on their machine is at `{{HOST_GATEWAY}}:<port>` from in here.
+
+## Running commands on the host
+
+Use the `run_command` MCP tool. Each distinct command string needs the user's
+approval through a desktop dialog; `list_allowed_commands` shows what they have
+already allowed for this workspace.
+
+Rules, in order of how often they matter:
+
+1. **Prefer the container.** Only go to the host for things that genuinely
+   cannot work in here: host-only tools, the user's browser or GUI, other
+   checkouts, `podman`/`docker`, services bound to the host.
+2. **Keep the command simple.** One command with plain arguments. Do not build
+   pipelines, do not redirect, do not chain with `&&` or `;`, and do not wrap
+   things in `bash -c "..."` to shape the output.
+3. **Never trim output on the host.** stdout and stderr are captured to files
+   you can read in full (see below), so `| head`, `| tail`, `| grep`, `> file`
+   and `2>&1` buy you nothing — `| head` and `| tail` are rejected outright.
+   Run the plain command and read as much of the output file as you need.
+4. **Don't `cd` to an absolute path first.** Host commands already start in the
+   workspace root, and a leading `cd /…` is rejected. A relative `cd sub && …`
+   is fine when a tool insists on a subdirectory.
+5. **Repeat command strings verbatim.** The user's allowlist matches on the
+   exact string, so re-running the identical command is silent while an added
+   flag or pipe pops a fresh approval dialog.
+
+### Reading the output
+
+`run_command` waits up to 5 seconds. If the command is still running you get a
+`command_id` back and the output keeps streaming into:
+
+```
+/app/.ai-pod/commands/{session_id}/{command_id}/stdout
+/app/.ai-pod/commands/{session_id}/{command_id}/stderr
+/app/.ai-pod/commands/{session_id}/{command_id}/exit
+```
+
+These are files in *this* container (the workspace is mounted at `/app`), so
+read them with your normal file Read tool — not with a host command. Re-read
+`stdout` to follow progress and `exit` to see whether it is done: it contains
+the decimal exit code, or `killed`. `command_status` is there for a quick
+status plus a 10-line tail; it is not a polling loop, the files are.
+
+### Stopping a command
+
+Use `stop_command` with the `command_id`. ai-pod runs every host command in its
+own process group and sends SIGTERM, then SIGKILL after 5 seconds, to the whole
+group. `list_commands` shows what this session started, with ids.
+
+**Do not run `kill`, `pkill`, `killall`, or `xargs kill` on the host.** You
+would be guessing at pids on the user's machine, and you can just as easily hit
+their editor, their dev server, or this session. If something is running on the
+host that ai-pod did not start, tell the user about it instead of killing it.
+
+## Service containers
+
+Need a database, cache, or broker? Do not install it into this container — call
+`start_service` with an image (`postgres:16`), a short `name`, and any env vars.
+The service joins this workspace's network and is reachable from here by that
+name on the image's standard port, e.g. `postgres:5432`. `list_services`,
+`service_logs`, and `stop_service` manage them. Services are ephemeral: their
+data is discarded when the session ends.
+
+## Getting the user's attention
+
+`notify_user` sends a desktop notification. Use it when a long job finished or
+you are blocked on a question and the user has walked away.
+
+## Changing this container
+
+The image is built from `/app/{{DOCKERFILE}}`. Edit that file to add tools,
+runtimes, or system packages permanently.
+
+Keep these intact:
+
+- `ARG HOST_GATEWAY` / `ARG AI_POD_VERSION` and the
+  `RUN curl -fsSL "http://${HOST_GATEWAY}:7822/install/<agent>.sh" | bash`
+  line — that is what installs the agent you are running as.
+- `WORKDIR /app`, the `ai-pod` user creation, `USER ai-pod`, and the final
+  `CMD`.
+
+Put root-level installs (`apt-get install …`, toolchains) *before* the
+`USER ai-pod` line and user-level installs after it.
+
+Then verify with the `rebuild_image` MCP tool:
+
+```json
+{ "test_command": "node --version && npx playwright --version" }
+```
+
+- It rebuilds the image from the current `{{DOCKERFILE}}` and, if the build
+  succeeds, runs `test_command` in a throwaway container of the fresh image.
+  The container is removed immediately; nothing in it persists, and the
+  workspace is not mounted, so test for tools rather than for project builds.
+- Build log and test output land in the same command output files as
+  `run_command`, with a `command_id` to follow if it takes more than 5 seconds.
+  A non-zero `exit` means either the build or the test failed — read `stdout`
+  and `stderr` to find out which.
+- Write a `test_command` that actually proves what you added is installed and
+  on `PATH`.
+- Do **not** run `podman build` or `docker build` through `run_command`;
+  `rebuild_image` is approved separately and knows the right image name, build
+  args, and context.
+- **The rebuild does not change the container you are in right now.** The new
+  image is picked up the next time the user starts ai-pod. When your change
+  matters for the current task, say so and ask the user to restart the pod.

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -468,6 +468,143 @@ fn e2e_container_workdir_is_app() {
     );
 }
 
+/// True when the runtime has an image with this tag. Uses `image inspect`,
+/// which both docker and podman implement (unlike `image exists`).
+fn image_present(rt: &ContainerRuntime, tag: &str) -> bool {
+    rt.command()
+        .args(["image", "inspect", tag])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// `container::refresh_skill_in_volume` drops the ai-pod skill into every
+/// agent's global skills directory inside the home volume.
+#[test]
+fn e2e_skill_is_written_into_home_volume() {
+    let rt = require_runtime!();
+    let tag = shared_image_tag(&rt);
+    let (_dir, config) = make_test_config();
+    let ws = tempfile::TempDir::new().unwrap();
+    let vol = workspace::volume_name(ws.path());
+    let prefix = workspace::container_prefix(ws.path());
+
+    cleanup_volume(&rt, &vol);
+    let created = rt
+        .command()
+        .args(["volume", "create", &vol])
+        .status()
+        .unwrap();
+    assert!(created.success());
+
+    container::refresh_skill_in_volume(&rt, &config, &vol, &prefix, tag).expect("install skill");
+
+    for path in ai_pod::skill::skill_paths("/home/ai-pod") {
+        let output = rt
+            .command()
+            .args([
+                "run",
+                "--rm",
+                "-v",
+                &format!("{}:/home/ai-pod", vol),
+                tag,
+                "cat",
+                &path,
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "skill missing at {path}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let body = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            body.starts_with("---\n"),
+            "skill at {path} lost its frontmatter"
+        );
+        assert!(body.contains("name: ai-pod"));
+        assert!(body.contains("rebuild_image"));
+        assert!(!body.contains("{{"), "unsubstituted placeholder in {path}");
+    }
+
+    // Re-running overwrites in place rather than failing on the existing file.
+    container::refresh_skill_in_volume(&rt, &config, &vol, &prefix, tag).expect("reinstall skill");
+
+    cleanup_volume(&rt, &vol);
+}
+
+/// The shell command behind the `rebuild_image` MCP tool really builds the
+/// workspace image and then runs the test command in a throwaway container.
+#[test]
+fn e2e_rebuild_and_test_command_builds_then_tests() {
+    let rt = require_runtime!();
+    let (ws, dockerfile) = make_test_workspace();
+    let tag = "ai-pod-e2e-rebuild:test";
+    cleanup_image(&rt, tag);
+
+    let cmd = image::rebuild_and_test_command(&rt, &dockerfile, tag, false, "git --version");
+    let output = std::process::Command::new("sh")
+        .args(["-c", &cmd])
+        .current_dir(ws.path())
+        .output()
+        .expect("run rebuild command");
+
+    assert!(
+        output.status.success(),
+        "rebuild+test failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("git version"),
+        "test command output missing: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    // The image the agent's next session would use now exists.
+    assert!(
+        image_present(&rt, tag),
+        "rebuild should leave the image behind"
+    );
+
+    cleanup_image(&rt, tag);
+}
+
+/// A failing test command surfaces as a non-zero exit even though the build
+/// itself succeeded — that is how the agent learns its tool is missing.
+#[test]
+fn e2e_rebuild_and_test_command_fails_when_tool_is_missing() {
+    let rt = require_runtime!();
+    let (ws, dockerfile) = make_test_workspace();
+    let tag = "ai-pod-e2e-rebuild-fail:test";
+    cleanup_image(&rt, tag);
+
+    let cmd = image::rebuild_and_test_command(
+        &rt,
+        &dockerfile,
+        tag,
+        false,
+        "definitely-not-installed --version",
+    );
+    let output = std::process::Command::new("sh")
+        .args(["-c", &cmd])
+        .current_dir(ws.path())
+        .output()
+        .expect("run rebuild command");
+
+    assert!(
+        !output.status.success(),
+        "missing tool should fail the test"
+    );
+    // Build succeeded, so the image is there; only the smoke test failed.
+    assert!(
+        image_present(&rt, tag),
+        "the build itself should have succeeded"
+    );
+
+    cleanup_image(&rt, tag);
+}
+
 // ---------------------------------------------------------------------------
 // Async helpers
 // ---------------------------------------------------------------------------

--- a/tests/e2e_agents.sh
+++ b/tests/e2e_agents.sh
@@ -28,4 +28,9 @@ git init -q "$WORK"
 # shellcheck disable=SC2086
 ai-pod --workdir "$WORK" --no-credential-check run $VERIFY_ARGS
 
+# The ai-pod skill must be seeded into the home volume so the agent can look up
+# how to reach the host, stop commands, and rebuild its own image.
+ai-pod --workdir "$WORK" --no-credential-check run \
+  cat /home/ai-pod/.claude/skills/ai-pod/SKILL.md | grep -q "^name: ai-pod$"
+
 echo "PASS: ${COMBO}"

--- a/website/index.html
+++ b/website/index.html
@@ -759,6 +759,31 @@
                     </div>
 
                     <div class="feature-card">
+                        <div class="feature-icon">📘</div>
+                        <h3>Injected ai-pod skill</h3>
+                        <p>
+                            Every container ships with an <code>ai-pod</code>
+                            skill the agent loads on demand: how to run host
+                            commands (simple, unpiped — the output is already in
+                            files it can read), how to stop them without
+                            reaching for <code>pkill</code>, and how the pod is
+                            wired together.
+                        </p>
+                    </div>
+
+                    <div class="feature-card">
+                        <div class="feature-icon">🧱</div>
+                        <h3>Self-adjusting environment</h3>
+                        <p>
+                            Missing a tool? The agent edits
+                            <code>ai-pod.Dockerfile</code> and calls
+                            <code>rebuild_image</code>, which rebuilds the image
+                            and runs its test command in a throwaway container —
+                            so it can prove the fix before you restart the pod.
+                        </p>
+                    </div>
+
+                    <div class="feature-card">
                         <div class="feature-icon">⚡</div>
                         <h3>On-demand service containers</h3>
                         <p>


### PR DESCRIPTION
Closes #146.

## The injected `ai-pod` skill

`templates/ai-pod-skill.md` is rendered per runtime (the host gateway differs between podman and docker) and written into the home volume on **every launch** — so an ai-pod upgrade refreshes it in long-lived volumes — at:

- `~/.claude/skills/ai-pod/SKILL.md` — Claude Code, and OpenCode (which also scans `~/.claude/skills`)
- `~/.codex/skills/ai-pod/SKILL.md` — Codex

Agents load skills on demand, so this costs nothing until it's needed. It covers:

- **Where the agent is** — `/app`, the persistent `$HOME` volume, everything else ephemeral, the host at `host.containers.internal` / `host.docker.internal`.
- **Host commands** — prefer the container; **keep the command simple**: no piping, redirecting, or chaining, because the full streams are already written to files the agent can `Read` (`| head`/`| tail` are rejected outright); no absolute `cd`; reuse command strings verbatim so the allowlist keeps matching.
- **Stopping commands** — `stop_command` with the `command_id`, **never `kill`/`pkill`/`killall` on the host**: those guess at pids on the user's machine and can take out their editor, dev server, or the session itself.
- **Service containers** — `start_service` instead of installing a database into the pod.
- **Changing the image** — what to edit in `ai-pod.Dockerfile`, what must stay intact, and how to verify.

Bind-mounting a host skills directory over the injected copy (`ai-pod mount add ~/.claude/skills`) hides it, so `build_mount_args` now prints a warning when a mount does that.

## The `rebuild_image` MCP tool

`rebuild_image { test_command, no_cache? }` rebuilds the workspace image from `ai-pod.Dockerfile` with the same build args and context the CLI uses and, **only if the build succeeds**, runs `test_command` in a throwaway container of the fresh image (`--rm`, no workspace mount — it tests the image, not the project).

It goes through the normal command runner, so the long build log lands in `/app/.ai-pod/commands/{session}/{id}/{stdout,stderr,exit}` and can be polled by re-reading files or stopped with `stop_command`. The running container is not affected; the new image is picked up on the next launch.

Approval gets its own per-workspace bucket (`ProjectState.allowed_rebuilds`), keyed by image name only and **not** by the test command — so approving once lets the agent iterate on its Dockerfile, while an always-allowed rebuild still grants no arbitrary host commands (and vice versa). The test command is quoted with single-quote escaping before it reaches `sh -c`.

Also tightened the `run_command` and `stop_command` tool descriptions along the same lines, and picked up the `Cargo.lock` version the 0.14.1 bump missed.

## Testing

- `cargo test --lib` — 229 pass, incl. new coverage for skill rendering/paths/shadow detection, the generated build+test command (context, build args, `--no-cache`, docker `--add-host`, injection-hostile test command), the rebuild approval key and its allowlist round-trip, and the tool schema.
- `cargo test --test e2e` — new tests for skill installation into a real volume (both paths, idempotent re-run) and for the rebuild command actually building and smoke-testing an image, including the failing-test-command case. In this sandbox Docker Hub is blocked, so all image-pulling e2e tests (pre-existing ones included) skip/fail on `alpine:latest`; both new paths were verified against a real Docker daemon using an MCR-based image instead — skill files land in both skill dirs with substituted placeholders, and the rebuild chain builds, runs the throwaway container, and fails as expected when the tool is missing.
- `tests/e2e_agents.sh` now also asserts the skill is present in the launched container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcR5YPqRGQtswGB5SfkGZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcR5YPqRGQtswGB5SfkGZF)_